### PR TITLE
ENG-612: Token Studio backend support: return details from synchronizeTokensFromData

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@supernovaio/supernova-sdk",
-    "version": "1.8.31",
+    "version": "1.8.39",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@supernovaio/supernova-sdk",
-            "version": "1.8.31",
+            "version": "1.8.39",
             "license": "MIT",
             "dependencies": {
                 "abab": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@supernovaio/supernova-sdk",
-    "version": "1.8.39",
+    "version": "1.8.40",
     "description": "Supernova.io Developer SDK",
     "main": "build/supernova-sdk-typescript.js",
     "typings": "build/Typescript/src/index.d.ts",

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -138,7 +138,10 @@ export { TokenThemeOverride } from './model/themes/SDKTokenThemeOverride'
 
 // Tooling
 export { TokenJSONBuilder, JSONBuilderNamingOption } from './tools/json-builder/SDKToolsJSONBuilder'
-export { SupernovaToolsDesignTokensPlugin } from '../src/tools/design-tokens/SDKToolsDesignTokensPlugin'
+export { DTProcessedTokenNode } from '../src/tools/design-tokens/utilities/SDKDTJSONConverter'
+export { DTTokenMergeDiff } from '../src/tools/design-tokens/utilities/SDKDTTokenMerger'
+export { DTPluginToSupernovaMap, DTPluginToSupernovaMapType } from '../src/tools/design-tokens/utilities/SDKDTMapLoader'
+export { SupernovaToolsDesignTokensPlugin, SupernovaToolsDesignTokensResult } from '../src/tools/design-tokens/SDKToolsDesignTokensPlugin'
 export { DocSearch, DocSearchConfiguration, DocSearchResult, DocSearchResultData, DocSearchResultDataType } from '../src/tools/search-index/SDKToolsDocSearch'
 export { MarkdownTransform, MarkdownTransformType } from '../src/tools/markdown-transform/SDKToolsMarkdownTransform'
 export { TokenTransform } from '../src/tools/token-transform/SDKToolsTokenTransform'

--- a/src/tools/design-tokens/SDKToolsDesignTokensPlugin.ts
+++ b/src/tools/design-tokens/SDKToolsDesignTokensPlugin.ts
@@ -35,7 +35,7 @@ export type SupernovaToolsDesignTokensLoadingResult = {
 }
 
 export type SupernovaToolsDesignTokensResult = {
-  map: DTPluginToSupernovaMap
+  map: Pick<DTPluginToSupernovaMap, 'bindToBrand' | 'bindToTheme' | 'pluginSets' | 'pluginTheme' | 'type'>
   tokens: Array<Token>
   groups?: Array<TokenGroup>
   diff?: DTTokenMergeDiff
@@ -124,7 +124,7 @@ export class SupernovaToolsDesignTokensPlugin {
         throw new Error(`Unknown brand ${map.bindToBrand} provided in binding.\n\nAvailable brands in this design system: [${brands.map(b => `${b.name} (id: ${b.persistentId})`)}]`)
       }
       const mergeResult = await this.mergeWithRemoteSource(map.processedNodes, brand, !settings.dryRun, settings.verbose, settings.preciseCopy)
-      results.push({ map, ...mergeResult });
+      results.push({ map: _.pick(map, ["bindToBrand", "bindToTheme", "pluginSets", "pluginTheme", "type"]), ...mergeResult });
       if (settings.verbose) {
         console.log(`✅ (task done) Synchronized base tokens for brand ${brand.name}`)
       }
@@ -146,7 +146,7 @@ export class SupernovaToolsDesignTokensPlugin {
         throw new Error(`Unknown theme ${map.bindToTheme} provided in binding.\n\nAvailable themes in this design system: ${brands.map(b => `Brand: ${b.name} (id: ${b.persistentId})\n${themes.filter(th => th.brandId == b.persistentId).map(t => `    Theme: ${t.name} (id: ${t.id})`)}`)}`)
       }
       const mergeResult = await this.mergeThemeWithRemoteSource(map.processedNodes, brand, theme, !settings.dryRun, settings.verbose)
-      results.push({ map, tokens: mergeResult.tokens })
+      results.push({ map: _.pick(map, ["bindToBrand", "bindToTheme", "pluginSets", "pluginTheme", "type"]), tokens: mergeResult.tokens })
       if (settings.verbose) {
         console.log(
           `✅ (task done) Synchronized themed tokens for brand ${brand.name}, theme ${theme.name}`

--- a/src/tools/design-tokens/SDKToolsDesignTokensPlugin.ts
+++ b/src/tools/design-tokens/SDKToolsDesignTokensPlugin.ts
@@ -17,12 +17,12 @@ import { DTJSONLoader, DTParsedNode, DTParsedTheme, DTParsedTokenSet } from './u
 import { DTJSONConverter, DTProcessedTokenNode } from './utilities/SDKDTJSONConverter'
 import { DTJSONGroupBuilder } from './utilities/SDKDTJSONGroupBuilder'
 import { DTTokenGroupTreeMerger } from './utilities/SDKDTTokenGroupTreeMerger'
-import { DTTokenMerger } from './utilities/SDKDTTokenMerger'
+import { DTTokenMergeDiff, DTTokenMerger } from './utilities/SDKDTTokenMerger'
 import { Brand } from '../../core/SDKBrand'
 import { DTMapResolver } from './utilities/SDKDTMapResolver'
 import { TokenTheme } from '../../model/themes/SDKTokenTheme'
 import { DTThemeMerger } from './utilities/SDKDTThemeMerger'
-import { DTMapLoader, DTPluginToSupernovaMapPack, DTPluginToSupernovaSettings } from './utilities/SDKDTMapLoader'
+import { DTMapLoader, DTPluginToSupernovaMap, DTPluginToSupernovaMapPack, DTPluginToSupernovaSettings } from './utilities/SDKDTMapLoader'
 import { DTJSONParser } from './utilities/SDKDTJSONParser'
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
@@ -32,6 +32,13 @@ export type SupernovaToolsDesignTokensLoadingResult = {
   processedNodes: Array<DTProcessedTokenNode>
   tokens: Array<Token>
   groups: Array<TokenGroup>
+}
+
+export type SupernovaToolsDesignTokensResult = {
+  map: DTPluginToSupernovaMap
+  tokens: Array<Token>
+  groups?: Array<TokenGroup>
+  diff?: DTTokenMergeDiff
 }
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
@@ -84,6 +91,17 @@ export class SupernovaToolsDesignTokensPlugin {
     mapping: DTPluginToSupernovaMapPack,
     settings: DTPluginToSupernovaSettings
   ): Promise<boolean> {
+    await this.synchronizeTokensFromDataWithResults(data, mapping, settings)
+    return true
+  }
+
+  async synchronizeTokensFromDataWithResults(
+    data: object,
+    mapping: DTPluginToSupernovaMapPack,
+    settings: DTPluginToSupernovaSettings
+  ): Promise<SupernovaToolsDesignTokensResult[] > {
+    const results: SupernovaToolsDesignTokensResult[] = []
+
     // Fetch brand and themes
     let brands = await this.version.brands()
     let themes = await this.version.themes()
@@ -105,7 +123,8 @@ export class SupernovaToolsDesignTokensPlugin {
       if (!brand) {
         throw new Error(`Unknown brand ${map.bindToBrand} provided in binding.\n\nAvailable brands in this design system: [${brands.map(b => `${b.name} (id: ${b.persistentId})`)}]`)
       }
-      await this.mergeWithRemoteSource(map.processedNodes, brand, !settings.dryRun, settings.verbose, settings.preciseCopy)
+      const mergeResult = await this.mergeWithRemoteSource(map.processedNodes, brand, !settings.dryRun, settings.verbose, settings.preciseCopy)
+      results.push({ map, ...mergeResult });
       if (settings.verbose) {
         console.log(`✅ (task done) Synchronized base tokens for brand ${brand.name}`)
       }
@@ -126,7 +145,8 @@ export class SupernovaToolsDesignTokensPlugin {
       if (!theme) {
         throw new Error(`Unknown theme ${map.bindToTheme} provided in binding.\n\nAvailable themes in this design system: ${brands.map(b => `Brand: ${b.name} (id: ${b.persistentId})\n${themes.filter(th => th.brandId == b.persistentId).map(t => `    Theme: ${t.name} (id: ${t.id})`)}`)}`)
       }
-      await this.mergeThemeWithRemoteSource(map.processedNodes, brand, theme, !settings.dryRun, settings.verbose)
+      const mergeResult = await this.mergeThemeWithRemoteSource(map.processedNodes, brand, theme, !settings.dryRun, settings.verbose)
+      results.push({ map, tokens: mergeResult.tokens })
       if (settings.verbose) {
         console.log(
           `✅ (task done) Synchronized themed tokens for brand ${brand.name}, theme ${theme.name}`
@@ -134,7 +154,7 @@ export class SupernovaToolsDesignTokensPlugin {
       }
     }
 
-    return true
+    return results
   }
 
   // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
@@ -312,6 +332,7 @@ export class SupernovaToolsDesignTokensPlugin {
   ): Promise<{
     tokens: Array<Token>
     groups: Array<TokenGroup>
+    diff: DTTokenMergeDiff
   }> {
     // Get remote token data
     let upstreamTokenGroups = await brand.tokenGroups()
@@ -369,7 +390,8 @@ export class SupernovaToolsDesignTokensPlugin {
 
     return {
       tokens: tokensToWrite,
-      groups: tokenGroupsToWrite
+      groups: tokenGroupsToWrite,
+      diff: tokenMergeResult
     }
   }
 
@@ -382,6 +404,7 @@ export class SupernovaToolsDesignTokensPlugin {
     verbose: boolean
   ): Promise<{
     theme: TokenTheme
+    tokens: Array<Token>
   }> {
     // Get remote token data
     let upstreamTokens = await brand.tokens()
@@ -404,7 +427,8 @@ export class SupernovaToolsDesignTokensPlugin {
     }
 
     return {
-      theme: theme
+      theme: theme,
+      tokens: themeMergerResult.overriddenTokens
     }
   }
 


### PR DESCRIPTION
### Changes
- Added `synchronizeTokensFromDataWithResults` method that returns imported results data from `mergeWithRemoteSource`.
  - Existing `synchronizeTokensFromData` should not be changed.
  - Keep `stop on first failure` behavior.
- Added `SupernovaToolsDesignTokensResult` as container for result data
- Export few related types
- Bump version