### PR TITLE
#token-studio - Bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@supernovaio/supernova-sdk",
-    "version": "1.8.39",
+    "version": "1.8.41",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@supernovaio/supernova-sdk",
-            "version": "1.8.39",
+            "version": "1.8.41",
             "license": "MIT",
             "dependencies": {
                 "abab": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@supernovaio/supernova-sdk",
-    "version": "1.8.40",
+    "version": "1.8.41",
     "description": "Supernova.io Developer SDK",
     "main": "build/supernova-sdk-typescript.js",
     "typings": "build/Typescript/src/index.d.ts",


### PR DESCRIPTION
## Changes
- Bump version

## Notes
Need to bump version and redeploy, as [Pulsar depends on specific path for imports](https://github.com/Supernova-Studio/Pulsar/pull/125) (`build/typescript`) and last deployment used `build/sdk-typescript`. Which makes this [API PR](https://github.com/Supernova-Studio/supernova-backend-node/pull/1120) blocked.