### PR TITLE
ENG-612: Token studio import set sourceId per design system & brand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@supernovaio/supernova-sdk",
-    "version": "1.8.41",
+    "version": "1.8.42",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@supernovaio/supernova-sdk",
-            "version": "1.8.41",
+            "version": "1.8.42",
             "license": "MIT",
             "dependencies": {
                 "abab": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@supernovaio/supernova-sdk",
-    "version": "1.8.41",
+    "version": "1.8.42",
     "description": "Supernova.io Developer SDK",
     "main": "build/supernova-sdk-typescript.js",
     "typings": "build/Typescript/src/index.d.ts",

--- a/src/core/SDKDesignSystem.ts
+++ b/src/core/SDKDesignSystem.ts
@@ -57,9 +57,6 @@ export class DesignSystem {
     /** Design system description */
     description: string
 
-    /** Sources that are used to feed the design system with the data (design & code) */
-    sources: Array<Source>
-
     /** If enabled, parts of the design system can be accessed by public (for example, documentation site) */
     isPublic: boolean
 
@@ -96,12 +93,6 @@ export class DesignSystem {
       this.documentationExporterId = model.docExporterId
       this.documentationSlug = model.docSlug
       this.documentationUserSlug = model.docUserSlug ?? null
-      
-      if (model.sources) {
-        this.sources = model.sources.map(s => new Source(s))
-      } else {
-        this.sources = []
-      }
     }
   
 
@@ -121,31 +112,34 @@ export class DesignSystem {
     }
 
     /** Get source by source id */
-    sourceById(sourceId: string): Source | undefined {
+    async sourceById(sourceId: string): Promise<Source | undefined> {
 
-      let source = this.sources.filter(s => s.id === sourceId)[0]
+      let sources = await this.sources()
+      let source = sources.filter(s => s.id === sourceId)[0]
       return source
     }
 
-    /** Fetches all sources that were created in the design system. */
-    async fetchSources(): Promise<Array<Source>> {
+    /** Fetches all sources that were created in the design system. Used to feed the design system with the data (design & code). */
+    async sources(): Promise<Array<Source>> {
 
       return this.engine.designSystemSources(this.id)
     }
 
     /** Get Figma file from source id */
-    figmaFileIdForSourceId(sourceId: string): string | undefined {
+    async figmaFileIdForSourceId(sourceId: string): Promise<string | undefined> {
 
-      let source = this.sources.filter(s => s.id === sourceId)[0]
+      let sources = await this.sources()
+      let source = sources.filter(s => s.id === sourceId)[0]
       if (source) {
         return source.fileId
       }
     }
 
     /** Get Figma file name from source id */
-    figmaFileNameForSourceId(sourceId: string): string | undefined {
+    async figmaFileNameForSourceId(sourceId: string): Promise<string | undefined> {
 
-      let source = this.sources.filter(s => s.id === sourceId)[0]
+      let sources = await this.sources()
+      let source = sources.filter(s => s.id === sourceId)[0]
       if (source) {
         return source.fileName
       }

--- a/src/core/SDKDesignSystem.ts
+++ b/src/core/SDKDesignSystem.ts
@@ -127,6 +127,12 @@ export class DesignSystem {
       return source
     }
 
+    /** Fetches all sources that were created in the design system. */
+    async fetchSources(): Promise<Array<Source>> {
+
+      return this.engine.designSystemSources(this.id)
+    }
+
     /** Get Figma file from source id */
     figmaFileIdForSourceId(sourceId: string): string | undefined {
 

--- a/src/core/SDKSupernova.ts
+++ b/src/core/SDKSupernova.ts
@@ -18,6 +18,7 @@ import { DesignSystemVersion } from "./SDKDesignSystemVersion"
 import { Workspace } from "./SDKWorkspace"
 import { SupernovaError } from "./errors/SDKSupernovaError"
 import { Exporter } from "../model/exporters/SDKExporter"
+import { Source } from "../model/support/SDKSource"
 
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
@@ -191,6 +192,19 @@ export class Supernova {
 
       return new DesignSystemVersion(this, ds, versionData)
   }
+
+  /** Fetches design system sources */
+  async designSystemSources(designSystemId: string): Promise<Array<Source>> {
+
+    // Fetch all sources belonging to one specific design system
+    const sourcesEndpoint = `design-systems/${designSystemId}/sources`
+    let sourcesData = (await this.dataBridge.getDSMGenericDataFromEndpoint(sourcesEndpoint)).sources
+    if (!sourcesData) {
+      throw SupernovaError.fromSDKError(`Unable to retrieve design system sources for id ${designSystemId}`)
+    }
+
+    return sourcesData.map(s => new Source(s))
+}
 
   /** Fetches exporters belonging to workspace by id */
   async exporters(workspaceId: string): Promise<Array<Exporter>> {

--- a/src/core/data/SDKDataCore.ts
+++ b/src/core/data/SDKDataCore.ts
@@ -870,9 +870,10 @@ export class DataCore {
     // For now, transform all designComponents into designComponents
     let designComponents: Array<DesignComponent> = []
     let ds = version.designSystem
+    let sources = await ds.sources()
 
     for (let designComponent of data) {
-      designComponents.push(new DesignComponent(designComponent, ds.sources))
+      designComponents.push(new DesignComponent(designComponent, sources))
     }
 
     // For duplicates

--- a/src/tools/design-tokens/SDKToolsDesignTokensPlugin.ts
+++ b/src/tools/design-tokens/SDKToolsDesignTokensPlugin.ts
@@ -107,7 +107,7 @@ export class SupernovaToolsDesignTokensPlugin {
     // Fetch brand and themes
     let brands = await this.version.brands()
     let themes = await this.version.themes()
-    let sources = await this.version.designSystem.fetchSources()
+    let sources = await this.version.designSystem.sources()
 
     // Parse data from object
     let parser = new DTJSONParser()


### PR DESCRIPTION
## Changes
 - We create `design_system_source` per brand now, so in `synchronizeTokensFromDataWithResults` `token.sourceId` now set by brand. I.e. for different brands there would be different `sourceId`.