### PR TITLE
#token-studio - Do not set token.origin if no source was found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@supernovaio/supernova-sdk",
-    "version": "1.8.43",
+    "version": "1.8.44",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@supernovaio/supernova-sdk",
-            "version": "1.8.43",
+            "version": "1.8.44",
             "license": "MIT",
             "dependencies": {
                 "abab": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@supernovaio/supernova-sdk",
-    "version": "1.8.43",
+    "version": "1.8.44",
     "description": "Supernova.io Developer SDK",
     "main": "build/supernova-sdk-typescript.js",
     "typings": "build/Typescript/src/index.d.ts",

--- a/src/tools/design-tokens/SDKToolsDesignTokensPlugin.ts
+++ b/src/tools/design-tokens/SDKToolsDesignTokensPlugin.ts
@@ -276,6 +276,10 @@ export class SupernovaToolsDesignTokensPlugin {
 
   private setTokensOrigin(map: DTPluginToSupernovaMap, brand: Brand, sources: Source[]): DTPluginToSupernovaMap {
     const sourceId = sources.find(s => s.type === SourceType.tokenStudio && s.brandId === brand.persistentId)?.id
+    if (!sourceId) {
+      return map
+    }
+    
     for (let node of map.processedNodes) {
       node.token.origin = {
         name: node.token.name,


### PR DESCRIPTION
## Changes
 - Seems, that during sync from CLI the data source could not be found, which makes `sourceId` undefined and not acceptable at BE. Thus we do not set `token.origin`, if we haven't found appropriate source, thus making it behave the way it was before introducing this method.

## Alternative
 - Second option (fast) is to revert `synchronizeTokensFromData` that used by CLI to a version without calling `setTokenOrigin`. In this case, we keep `fail or no source created` behavior for API, instead of silently `not setting it to token.origin`
 - Third option (long, not in one PR) would be to update CLI which uses SDK to call API `POST .../token-studio` or create a method inside SDK that does it (need further investigation on how that would work, specifically test/release process).
 - Fourth option (long, not in one PR) would be to move create source to SDK or move import tokens to API (need discussion)