### PR TITLE
EPDA-2: Update doc images

### DIFF
--- a/src/exports.ts
+++ b/src/exports.ts
@@ -1,5 +1,3 @@
-
-
 // Export main Supernova object
 export { Supernova } from '../src/core/SDKSupernova'
 
@@ -72,13 +70,13 @@ export { DocumentationPageBlockTableColumn } from '../src/model/documentation/bl
 export { DocumentationItemHeader } from '../src/model/documentation/configuration/SDKDocumentationItemHeader'
 export { DocumentationItemConfiguration } from '../src/model/documentation/configuration/SDKDocumentationItemConfiguration'
 
-
 // Documentation / Main
 export { DocumentationConfiguration } from '../src/model/documentation/SDKDocumentationConfiguration'
 export { DocumentationGroup } from '../src/model/documentation/SDKDocumentationGroup'
 export { DocumentationItem } from '../src/model/documentation/SDKDocumentationItem'
 export { DocumentationPage } from '../src/model/documentation/SDKDocumentationPage'
 export { DocumentationPageBlock } from '../src/model/documentation/SDKDocumentationPageBlock'
+export { DocumentationPageAsset } from '../src/model/documentation/SDKDocumentationPageAsset'
 export { DocumentationRichText } from '../src/model/documentation/SDKDocumentationRichText'
 export { RichTextSpan } from '../src/model/documentation/SDKDocumentationRichTextSpan'
 export { RichTextSpanAttribute } from '../src/model/documentation/SDKDocumentationRichTextSpanAttribute'
@@ -99,6 +97,7 @@ export { DocumentationCalloutType } from '../src/model/enums/SDKDocumentationCal
 export { DocumentationGroupBehavior } from '../src/model/enums/SDKDocumentationGroupBehavior'
 export { DocumentationHeadingType } from '../src/model/enums/SDKDocumentationHeadingType'
 export { DocumentationItemType } from '../src/model/enums/SDKDocumentationItemType'
+export { DocumentationPageAssetType } from '../src/model/enums/SDKDocumentationPageAssetType'
 export { DocumentationPageBlockType } from '../src/model/enums/SDKDocumentationPageBlockType'
 export { DocumentationPageBlockThemeType } from './model/enums/SDKDocumentationPageBlockThemeType'
 export { FrameAlignment } from '../src/model/enums/SDKFrameAlignment'

--- a/src/model/documentation/SDKDocumentationPageAsset.ts
+++ b/src/model/documentation/SDKDocumentationPageAsset.ts
@@ -1,0 +1,38 @@
+// --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
+// MARK: - Imports
+
+import { DocumentationPageAssetType } from '../enums/SDKDocumentationPageAssetType'
+import { DocumentationPageBlockFrame, DocumentationPageBlockFrameModel } from './blocks/SDKDocumentationPageBlockFrame'
+
+// --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
+// MARK: - Definitions
+
+export interface DocumentationPageAssetModel {
+  id: string
+  url?: string
+  type: DocumentationPageAssetType
+  figmaFrame?: DocumentationPageBlockFrameModel
+}
+
+// --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
+// MARK: -  Object Definition
+
+export class DocumentationPageAsset {
+  // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
+  // MARK: - Public properties
+
+  id: string
+  url: string | null
+  type: DocumentationPageAssetType
+  frame: DocumentationPageBlockFrame | null
+
+  // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
+  // MARK: - Constructor
+
+  constructor(model: DocumentationPageAssetModel) {
+    this.id = model.id
+    this.url = model.url ?? null
+    this.type = model.type
+    this.frame = model.figmaFrame ? new DocumentationPageBlockFrame(model.figmaFrame, null) : null
+  }
+}

--- a/src/model/documentation/blocks/SDKDocumentationPageBlockCustom.ts
+++ b/src/model/documentation/blocks/SDKDocumentationPageBlockCustom.ts
@@ -66,6 +66,12 @@ export class DocumentationPageBlockCustom extends DocumentationPageBlock {
     // Add overrides
     for (let property of model.customBlockProperties) {
       properties[property.key] = property.value
+
+      // Deprecated. Old image asset type for backward compatibility
+      if (property.value?.asset || property.value?.asset === null) {
+        property.value.assetId = property.value.asset?.id ?? null
+        property.value.assetUrl = property.value.asset?.url ?? null
+      }
     }
     this.properties = properties
   }

--- a/src/model/documentation/blocks/SDKDocumentationPageBlockImage.ts
+++ b/src/model/documentation/blocks/SDKDocumentationPageBlockImage.ts
@@ -13,12 +13,15 @@ import { Alignment } from "../../enums/SDKAlignment"
 import { ExporterCustomBlock } from "../../exporters/custom_blocks/SDKExporterCustomBlock"
 import { DocumentationConfiguration } from "../SDKDocumentationConfiguration"
 import { DocumentationPageBlockModel, DocumentationPageBlock } from "../SDKDocumentationPageBlock"
+import { DocumentationPageAssetModel, DocumentationPageAsset } from "../SDKDocumentationPageAsset"
 
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 // MARK: - Definitions
 
 export interface DocumentationPageBlockImageModel extends DocumentationPageBlockModel {
+  asset?: DocumentationPageAssetModel
+  // Deprecated. Was replaced with `asset.url`
   assetUrl?: string
   caption?: string
   alignment: Alignment
@@ -32,6 +35,7 @@ export class DocumentationPageBlockImage extends DocumentationPageBlock {
   // MARK: - Public properties
 
   url: string | null
+  asset: DocumentationPageAsset
   caption: string | null
   alignment: Alignment
 
@@ -40,7 +44,8 @@ export class DocumentationPageBlockImage extends DocumentationPageBlock {
 
   constructor(model: DocumentationPageBlockImageModel, customBlocks: Array<ExporterCustomBlock>, configuration: DocumentationConfiguration) {
     super(model, customBlocks, configuration)
-    this.url = model.assetUrl ?? null
+    this.url = model.assetUrl ?? model.asset?.url ?? null
+    this.asset = model.asset?.id ? new DocumentationPageAsset(model.asset) : null
     this.caption = model.caption ?? null
     this.alignment = model.alignment
   }

--- a/src/model/documentation/blocks/SDKDocumentationPageBlockShortcut.ts
+++ b/src/model/documentation/blocks/SDKDocumentationPageBlockShortcut.ts
@@ -12,10 +12,15 @@
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 // MARK: - Definitions
 
+import { DocumentationPageAssetModel } from "../SDKDocumentationPageAsset"
+
 export interface DocumentationPageBlockShortcutModel {
   title?: string
   description?: string
+  asset?: DocumentationPageAssetModel
+  // Deprecated. Was replaced with `asset.id`
   assetId?: string
+  // Deprecated. Was replaced with `asset.id`
   assetUrl?: string
   documentationItemId?: string
   url?: string
@@ -133,6 +138,6 @@ export class DocumentationPageBlockShortcut {
     model: DocumentationPageBlockShortcutModel,
     type: DocumentationPageBlockShortcutType
   ): string | null {
-    return model.assetUrl ?? model.urlPreview?.thumbnailUrl ?? null
+    return model.assetUrl ?? model.asset?.url ?? model.urlPreview?.thumbnailUrl ?? null
   }
 }

--- a/src/model/documentation/configuration/SDKDocumentationItemHeader.ts
+++ b/src/model/documentation/configuration/SDKDocumentationItemHeader.ts
@@ -6,26 +6,28 @@
 //  Copyright © 2021 Supernova. All rights reserved.
 //
 
-
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 // MARK: - Imports
 
-import { ColorTokenRemoteData } from "../../../model/tokens/remote/SDKRemoteTokenData"
-import { Alignment } from "../../../model/enums/SDKAlignment"
-import { AssetScaleType } from "../../../model/enums/SDKAssetScaleType"
-
+import { ColorTokenRemoteData } from '../../../model/tokens/remote/SDKRemoteTokenData'
+import { Alignment } from '../../../model/enums/SDKAlignment'
+import { AssetScaleType } from '../../../model/enums/SDKAssetScaleType'
+import { DocumentationPageAssetModel } from '../SDKDocumentationPageAsset'
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 // MARK: - Definitions
 
 export interface DocumentationItemHeaderModel {
-  backgroundImageAssetUrl?: string
   description: string
   alignment: Alignment
   foregroundColor?: ColorTokenRemoteData
   backgroundColor?: ColorTokenRemoteData
+  backgroundImageAsset?: DocumentationPageAssetModel
+  // Deprecated. Was replaced with `backgroundImageAsset.url`
+  backgroundImageAssetUrl?: string
+  // Deprecated. Was replaced with `backgroundImageAsset.id`
   backgroundImageAssetId?: string
-  backgroundImageScaleType:  AssetScaleType
+  backgroundImageScaleType: AssetScaleType
   showBackgroundOverlay: boolean
   showCoverText: boolean
   minHeight: number
@@ -40,7 +42,7 @@ export class DocumentationItemHeader {
 
   backgroundImageAssetUrl: string | null
   backgroundImageAssetId: string | null
-  backgroundImageScaleType:  AssetScaleType
+  backgroundImageScaleType: AssetScaleType
 
   description: string
 
@@ -55,9 +57,8 @@ export class DocumentationItemHeader {
   // MARK: - Constructor
 
   constructor(model: DocumentationItemHeaderModel) {
-
-    this.backgroundImageAssetUrl = model.backgroundImageAssetUrl ?? null
-    this.backgroundImageAssetId = model.backgroundImageAssetId ?? null
+    this.backgroundImageAssetUrl = model.backgroundImageAssetUrl ?? model.backgroundImageAsset?.url ?? null
+    this.backgroundImageAssetId = model.backgroundImageAssetId ?? model.backgroundImageAsset?.id ?? null
     this.backgroundImageScaleType = model.backgroundImageScaleType
 
     this.description = model.description

--- a/src/model/enums/SDKDocumentationPageAssetType.ts
+++ b/src/model/enums/SDKDocumentationPageAssetType.ts
@@ -1,0 +1,7 @@
+// --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
+// MARK: - Source type enum
+
+export enum DocumentationPageAssetType {
+  image = 'image',
+  figmaFrame = 'figmaFrame'
+}


### PR DESCRIPTION
- Adds support for updated documentation page API for images that can hold figma frames.
- I tried to make these changes backward compatible to what already was there, so with these changes supernova-sdk can work with old and new API image models