### PR TITLE
#token-studio - Respect $metadata.json -> tokenSetOrder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@supernovaio/supernova-sdk",
-    "version": "1.8.63",
+    "version": "1.8.64",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@supernovaio/supernova-sdk",
-            "version": "1.8.63",
+            "version": "1.8.64",
             "license": "MIT",
             "dependencies": {
                 "abab": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@supernovaio/supernova-sdk",
-    "version": "1.8.63",
+    "version": "1.8.64",
     "description": "Supernova.io Developer SDK",
     "main": "build/supernova-sdk-typescript.js",
     "typings": "build/Typescript/src/index.d.ts",

--- a/src/tests/Tooling/PluginFigmaTokens.spec.ts
+++ b/src/tests/Tooling/PluginFigmaTokens.spec.ts
@@ -167,12 +167,12 @@ test('test_tooling_design_tokens_order', async t => {
 
   const validateToken = (tokens: Token[], description: string, hex: string, name: string) => {
     const token = tokens.filter(t => t.description === description)[0] as ColorToken
-    t.assert(!!token)
+    t.true(!!token)
     const ref = tokens.filter(t => t.id === token.value.referencedToken.id)[0] as ColorToken
-    t.assert(!!ref)
-    t.assert(token.value.hex === hex)
-    t.assert(ref.value.hex === hex)
-    t.assert(ref.name === name)
+    t.true(!!ref)
+    t.is(token.value.hex, hex)
+    t.is(ref.value.hex, hex)
+    t.is(ref.name, name)
   }
 
   const tokens = await version.tokens()

--- a/src/tests/Tooling/PluginFigmaTokens.spec.ts
+++ b/src/tests/Tooling/PluginFigmaTokens.spec.ts
@@ -24,6 +24,8 @@ import {
   DTPluginToSupernovaMapType,
   DTPluginToSupernovaSettings
 } from '../../tools/design-tokens/utilities/SDKDTMapLoader'
+import { Token } from '../../model/tokens/SDKToken'
+import { ColorToken } from 'index'
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 // MARK: - Tests
@@ -137,6 +139,47 @@ test('test_tooling_design_tokens_test', async t => {
 })
 
 
+test('test_tooling_design_tokens_order', async t => {
+  // Fetch specific design system version
+  let version = await testInstance.designSystemVersion(
+    process.env.TEST_DB_DESIGN_SYSTEM_ID,
+    process.env.TEST_DB_DESIGN_SYSTEM_VERSION_ID
+  )
+
+  // Path to file
+  let dataFilePath = path.join(process.cwd(), 'test-resources', 'figma-tokens', 'token-order-sync')
+  let mappingFilePath = path.join(
+    process.cwd(),
+    'test-resources',
+    'figma-tokens',
+    'token-order-sync',
+    'supernova.settings.json'
+  )
+
+  // Get Figma Tokens synchronization tool
+  let syncTool = new SupernovaToolsDesignTokensPlugin(version)
+  let dataLoader = new FigmaTokensDataLoader()
+  let tokenDefinition = await dataLoader.loadTokensFromDirectory(dataFilePath, mappingFilePath)
+  let configDefinition = dataLoader.loadConfigFromPath(mappingFilePath)
+
+  // Run sync
+  await t.notThrowsAsync(syncTool.synchronizeTokensFromData(tokenDefinition, configDefinition.mapping, configDefinition.settings))
+
+  const validateToken = (tokens: Token[], description: string, hex: string, name: string) => {
+    const token = tokens.filter(t => t.description === description)[0] as ColorToken
+    t.assert(!!token)
+    const ref = tokens.filter(t => t.id === token.value.referencedToken.id)[0] as ColorToken
+    t.assert(!!ref)
+    t.assert(token.value.hex === hex)
+    t.assert(ref.value.hex === hex)
+    t.assert(ref.name === name)
+  }
+
+  const tokens = await version.tokens()
+  validateToken(tokens, 'ocean-primary-default', '0000ffff', 'blue')
+  validateToken(tokens, 'forest-primary-default', '00ff00ff', 'green')
+})
+
 export class FigmaTokensDataLoader {
 
   /** Load token definitions from path */
@@ -188,7 +231,7 @@ export class FigmaTokensDataLoader {
       // Try to load metadata, if any
       let metadataPath = pathToDirectory + '/' + '$metadata.json'
       if (fs.existsSync(metadataPath)) {
-        let metadata = await this.loadObjectFile(themePath)
+        let metadata = await this.loadObjectFile(metadataPath)
         fullStructuredObject['$metadata'] = metadata
       }
 

--- a/src/tools/design-tokens/utilities/SDKDTJSONParser.ts
+++ b/src/tools/design-tokens/utilities/SDKDTJSONParser.ts
@@ -127,7 +127,7 @@ export class DTJSONParser {
         }
 
         // Process token sets
-        let pairedSets = new Array<any>()
+        let pairedSets = new Array<{ name: string, pair: any }>()
         for (let [tokenSetName, unknownPriority] of Object.entries(selectedTokenSets)) {
           let setName = tokenSetName
           let setPriority = unknownPriority
@@ -136,11 +136,16 @@ export class DTJSONParser {
             priority: setPriority as DTParsedThemeSetPriority,
             set: fetchedSet
           }
-          pairedSets.push(pair)
+          pairedSets.push({ name: setName, pair })
+        }
+
+        // Respect $metadata.json -> tokenSetOrder
+        if (order.length) {
+          pairedSets.sort((a,b) => order.indexOf(a.name) - order.indexOf(b.name))
         }
 
         let theme: DTParsedTheme = {
-          selectedTokenSets: pairedSets,
+          selectedTokenSets: pairedSets.map(o => o.pair),
           name: name,
           id: id
         }

--- a/src/tools/design-tokens/utilities/SDKDTTokenReferenceResolver.ts
+++ b/src/tools/design-tokens/utilities/SDKDTTokenReferenceResolver.ts
@@ -25,7 +25,7 @@ export class DTTokenReferenceResolver {
   // MARK: - Properties
 
   private mappedTokens: Map<string, Token> = new Map<string, Token>()
-  private nodes: Array<DTProcessedTokenNode> = []
+  private nodes: Map<string,DTProcessedTokenNode> = new Map<string, DTProcessedTokenNode>()
 
   // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
   // MARK: - Constructor
@@ -37,10 +37,11 @@ export class DTTokenReferenceResolver {
 
   addAtomicToken(token: DTProcessedTokenNode) {
     let nodePath = this.tokenReferenceKey(token.path, token.token.name)
-    if (!this.mappedTokens.get(nodePath)) {
-      this.mappedTokens.set(nodePath, token.token)
-      this.nodes.push(token)
-    }
+    // Always update tokens, as we process them in order from $metadata.json
+    // And Plugin using `last one wins` strategy
+    // See `test_tooling_design_tokens_order` test 
+    this.mappedTokens.set(nodePath, token.token)
+    this.nodes.set(nodePath, token)
   }
 
   addAtomicTokens(tokens: Array<DTProcessedTokenNode>) {
@@ -50,7 +51,7 @@ export class DTTokenReferenceResolver {
   }
 
   unmappedValues(): Array<DTProcessedTokenNode> {
-    return this.nodes
+    return [...this.nodes.values()]
   }
 
   // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---

--- a/test-resources/figma-tokens/token-order-sync/$metadata.json
+++ b/test-resources/figma-tokens/token-order-sync/$metadata.json
@@ -1,0 +1,8 @@
+{
+  "tokenSetOrder": [
+    "base",
+    "global",
+    "forest",
+    "ocean"
+  ]
+}

--- a/test-resources/figma-tokens/token-order-sync/$themes.json
+++ b/test-resources/figma-tokens/token-order-sync/$themes.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "079b44a8b28ed46aff5be1542d750aaa12222222",
+    "name": "Forest",
+    "selectedTokenSets": {
+      "global": "enabled",
+      "forest": "enabled",
+      "base": "enabled"
+    }
+  },
+  {
+    "id": "079b44a8b28ed46aff5be1542d750aaa13333333",
+    "name": "Ocean",
+    "selectedTokenSets": {
+      "base": "enabled",
+      "global": "enabled",
+      "ocean": "enabled"
+    },
+    "$figmaStyleReferences": {}
+  }
+]

--- a/test-resources/figma-tokens/token-order-sync/base.json
+++ b/test-resources/figma-tokens/token-order-sync/base.json
@@ -1,0 +1,23 @@
+{
+  "ds": {
+    "base": {
+      "color": {
+        "blue": {
+          "value": "#0000FF",
+          "type": "color",
+          "description": "blue"
+        },
+        "snow": {
+          "value": "#FFFAFA",
+          "type": "color",
+          "description": "snow"
+        },
+        "green": {
+          "value": "#00FF00",
+          "type": "color",
+          "description": "green"
+        }
+      }
+    }
+  }
+}

--- a/test-resources/figma-tokens/token-order-sync/forest.json
+++ b/test-resources/figma-tokens/token-order-sync/forest.json
@@ -1,0 +1,15 @@
+{
+  "ds": {
+    "sys": {
+      "color": {
+        "primary": {
+          "default": {
+            "value": "{ds.base.color.green}",
+            "type": "color",
+            "description": "forest-primary-default"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test-resources/figma-tokens/token-order-sync/global.json
+++ b/test-resources/figma-tokens/token-order-sync/global.json
@@ -1,0 +1,15 @@
+{
+  "ds": {
+    "sys": {
+      "color": {
+        "primary": {
+          "default": {
+            "value": "{ds.base.color.snow}",
+            "type": "color",
+            "description": "global-primary-default"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test-resources/figma-tokens/token-order-sync/ocean.json
+++ b/test-resources/figma-tokens/token-order-sync/ocean.json
@@ -1,0 +1,15 @@
+{
+  "ds": {
+    "sys": {
+      "color": {
+        "primary": {
+          "default": {
+            "value": "{ds.base.color.blue}",
+            "type": "color",
+            "description": "ocean-primary-default"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test-resources/figma-tokens/token-order-sync/supernova.settings.json
+++ b/test-resources/figma-tokens/token-order-sync/supernova.settings.json
@@ -1,0 +1,20 @@
+{
+  "mode": "multi-file",
+  "mapping": [
+    {
+      "tokensTheme": "Ocean",
+      "supernovaBrand": "Ocean",
+      "supernovaTheme": null
+    },
+    {
+      "tokensTheme": "Forest",
+      "supernovaBrand": "Forest",
+      "supernovaTheme": null
+    }
+  ],
+  "settings": {
+    "dryRun": false,
+    "verbose": true,
+    "preciseCopy": false
+  }
+}


### PR DESCRIPTION
## Changes

- Respect `$metadata.json -> tokenSetOrder` when building `DTParsedTheme.selectedTokenSets`

## Notes
- Not sure whether we need more sophisticated logic, i.e. whether order in `$metadata.json` might be invalid and have some set1 that references set2 earlier in list.