### PR TITLE
Bugfixes/numeric measures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this SDK are mentioned here in this changelog.
 
-## [1.8.45] - 2023-03-03
+## [1.8.46] - 2023-03-03
 ### User object
 
 We have added new function to the core `Supernova` object - `.me()` - which retrieves user profile associated with the provided API key.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@supernovaio/supernova-sdk",
-    "version": "1.8.63",
+    "version": "1.8.64",
     "description": "Supernova.io Developer SDK",
     "main": "build/supernova-sdk-typescript.js",
     "typings": "build/Typescript/src/index.d.ts",

--- a/src/model/tokens/SDKBorderToken.ts
+++ b/src/model/tokens/SDKBorderToken.ts
@@ -72,12 +72,14 @@ export class BorderToken extends Token {
       data: {},
       customPropertyOverrides: []
     }
-
+    console.log("creating  border token value")
     if (value) {
       // Raw value
+      console.log("creating raw token")
       let tokenValue = this.borderValueFromDefinition(value, referenceResolver)
       return new BorderToken(version, baseToken, tokenValue, undefined, properties, propertyValues)
     } else if (alias) {
+      console.log("creating aliased token")
       // Aliased value - copy and create raw from reference
       let tokenValue: BorderTokenValue = {
         color: alias.value.color,

--- a/src/model/tokens/SDKBorderToken.ts
+++ b/src/model/tokens/SDKBorderToken.ts
@@ -72,14 +72,11 @@ export class BorderToken extends Token {
       data: {},
       customPropertyOverrides: []
     }
-    console.log("creating  border token value")
     if (value) {
       // Raw value
-      console.log("creating raw token")
       let tokenValue = this.borderValueFromDefinition(value, referenceResolver)
       return new BorderToken(version, baseToken, tokenValue, undefined, properties, propertyValues)
     } else if (alias) {
-      console.log("creating aliased token")
       // Aliased value - copy and create raw from reference
       let tokenValue: BorderTokenValue = {
         color: alias.value.color,

--- a/src/model/tokens/SDKMeasureToken.ts
+++ b/src/model/tokens/SDKMeasureToken.ts
@@ -56,7 +56,7 @@ export class MeasureToken extends Token {
     brand: Brand,
     name: string,
     description: string,
-    value: string,
+    value: string | number,
     alias: MeasureToken | null,
     properties: Array<ElementProperty>,
     propertyValues: Array<ElementPropertyValue>
@@ -75,7 +75,7 @@ export class MeasureToken extends Token {
       customPropertyOverrides: []
     }
 
-    if (value) {
+    if (value !== null && value !== undefined) {
       let tokenValue = this.measureValueFromDefinition(value)
       return new MeasureToken(version, baseToken, tokenValue, undefined, properties, propertyValues)
     } else if (alias) {
@@ -89,7 +89,15 @@ export class MeasureToken extends Token {
     }
   }
 
-  static measureValueFromDefinition(definition: string): MeasureTokenValue {
+  static measureValueFromDefinition(definition: string | number): MeasureTokenValue {
+    if (typeof definition === "number") {
+      return {
+        measure: definition,
+        unit: Unit.pixels,
+        referencedToken: null
+      }
+    }
+
     let result = this.parseMeasure(definition)
     return {
       measure: result.measure,

--- a/src/model/tokens/SDKRadiusToken.ts
+++ b/src/model/tokens/SDKRadiusToken.ts
@@ -72,7 +72,7 @@ export class RadiusToken extends Token {
       customPropertyOverrides: []
     }
 
-    if (value) {
+    if (value !== undefined && value !== null) {
       // Raw value
       let tokenValue = this.radiusValueFromDefinition(value)
       return new RadiusToken(version, baseToken, tokenValue, undefined, properties, propertyValues)
@@ -118,7 +118,18 @@ export class RadiusToken extends Token {
     }
   }
 
-  static radiusValueFromDefinition(definition: string): RadiusTokenValue {
+  static radiusValueFromDefinition(definition: string | number): RadiusTokenValue {
+    if (typeof definition === "number") {
+      return {
+        radius: MeasureToken.measureValueFromDefinition(definition),
+        topLeft: null,
+        topRight: null,
+        bottomLeft: null,
+        bottomRight: null,
+        referencedToken: null
+      }
+    }
+
     let corners = definition.split(',')
     if (corners.length === 1) {
       // Uniform corner description

--- a/src/model/tokens/SDKTypographyToken.ts
+++ b/src/model/tokens/SDKTypographyToken.ts
@@ -156,9 +156,6 @@ export class TypographyToken extends Token {
       value.textCase = TextCase.original
     }
 
-    console.log(this.name)
-    console.log(value.fontSize)
-
     return value
   }
 

--- a/src/model/tokens/SDKTypographyToken.ts
+++ b/src/model/tokens/SDKTypographyToken.ts
@@ -156,6 +156,9 @@ export class TypographyToken extends Token {
       value.textCase = TextCase.original
     }
 
+    console.log(this.name)
+    console.log(value.fontSize)
+
     return value
   }
 

--- a/src/tools/design-tokens/SDKToolsDesignTokensPlugin.ts
+++ b/src/tools/design-tokens/SDKToolsDesignTokensPlugin.ts
@@ -180,7 +180,6 @@ export class SupernovaToolsDesignTokensPlugin {
       }
       let converter = new DTJSONConverter(this.version, mapping)
       let groupBuilder = new DTJSONGroupBuilder(this.version, mapping)
-
       let processedNodes = converter.convertNodesToTokens(map.nodes, brand)
       let processedGroups = groupBuilder.constructAllDefinableGroupsTrees(processedNodes, brand)
       map.processedNodes = processedNodes

--- a/src/tools/design-tokens/utilities/SDKDTJSONConverter.ts
+++ b/src/tools/design-tokens/utilities/SDKDTJSONConverter.ts
@@ -84,22 +84,16 @@ export class DTJSONConverter {
     )
     // Other tokens
     // this.convertNodesToTokensForSupportedNodeTypes(['other'], nodes, brand)
-
     // Color tokens
     this.convertNodesToTokensForSupportedNodeTypes(['color'], nodes, brand)
-
     // Radii tokens
     this.convertNodesToTokensForSupportedNodeTypes(['borderRadius'], nodes, brand)
-
     // Shadow tokens
     this.convertNodesToTokensForSupportedNodeTypes(['boxShadow'], nodes, brand)
-
     // Typography tokens
     this.convertNodesToTokensForSupportedNodeTypes(['typography'], nodes, brand)
-
     // Border tokens
     this.convertNodesToTokensForSupportedNodeTypes(['border'], nodes, brand)
-
     // Fix nodes so they are aligned with the way Supernova expects root groups to be named
     let processedNodes = this.referenceResolver.unmappedValues()
     this.remapRootNodeKeys(processedNodes)
@@ -227,7 +221,6 @@ export class DTJSONConverter {
       }
       unprocessedTokens = unprocessedDepthTokens
       depth += 1
-
       if (depth > maximumDepth) {
         throw new Error(
           `Engine was not able to solve references for the following tokens in a reasonable time: \n\n${unprocessedTokens

--- a/src/tools/design-tokens/utilities/SDKDTJSONConverter.ts
+++ b/src/tools/design-tokens/utilities/SDKDTJSONConverter.ts
@@ -82,18 +82,25 @@ export class DTJSONConverter {
       nodes,
       brand
     )
+    
     // Other tokens
     // this.convertNodesToTokensForSupportedNodeTypes(['other'], nodes, brand)
+
     // Color tokens
     this.convertNodesToTokensForSupportedNodeTypes(['color'], nodes, brand)
+
     // Radii tokens
     this.convertNodesToTokensForSupportedNodeTypes(['borderRadius'], nodes, brand)
+
     // Shadow tokens
     this.convertNodesToTokensForSupportedNodeTypes(['boxShadow'], nodes, brand)
+
     // Typography tokens
     this.convertNodesToTokensForSupportedNodeTypes(['typography'], nodes, brand)
+
     // Border tokens
     this.convertNodesToTokensForSupportedNodeTypes(['border'], nodes, brand)
+
     // Fix nodes so they are aligned with the way Supernova expects root groups to be named
     let processedNodes = this.referenceResolver.unmappedValues()
     this.remapRootNodeKeys(processedNodes)

--- a/src/tools/design-tokens/utilities/SDKDTTokenReferenceResolver.ts
+++ b/src/tools/design-tokens/utilities/SDKDTTokenReferenceResolver.ts
@@ -164,7 +164,7 @@ export class DTTokenReferenceResolver {
     return this.hasSameNumberOfCharacters(syntax, '{', '}')
   }
 
-  valueHasReference(value: string | object): boolean {
+  valueHasReference(value: string | object | number): boolean {
     if (typeof value !== 'string') {
       return false
     }


### PR DESCRIPTION
This PR adds option to define measures as numbers. Fixes doordash issue. The problem was, specifically, that if value is "0", `if (value)` actually resolves to false and in particular place, it created referenced measure token instead of raw value, leading to completely impossibly to track issue.