### PR TITLE
#token-studio - Unlink existing non-overriden Figma tokens

### DIFF
--- a/src/tools/design-tokens/utilities/SDKDTTokenMerger.ts
+++ b/src/tools/design-tokens/utilities/SDKDTTokenMerger.ts
@@ -138,6 +138,14 @@ export class DTTokenMerger {
       const key = DTTokenMerger.buildKey(node.path, node.token.name)
       if (!extractedMap.has(key)) {
         toDelete.push(node)
+        
+        // Any tokens and theme overrides that were imported from Figma are unlinked (turned into SN tokens)
+        // If preciseCopy = false, we should still unlink Figma tokens, that do not match any tokens from extracted from payload 
+        if (!!node.token.origin) {
+          node.token.origin = null
+          toUpdate.push(node)
+          toCreateOrUpdate.push(node)
+        }
       }
     }
 


### PR DESCRIPTION
## Changes

 - During import from TS Plugin unlink all Figma tokens that are not overriden (turn them into SN tokens)

## Notes
 - Case 3 and 9 in [Notion](https://www.notion.so/supernovaio/Tokens-Studio-5a1ca73cc4cc4d508b1be48f83d6b78e?pvs=4).