### PR TITLE
ENG-870 - Update refs for already built atomic nodes on node with same path

### DIFF
--- a/src/tests/Tooling/PluginFigmaTokens.spec.ts
+++ b/src/tests/Tooling/PluginFigmaTokens.spec.ts
@@ -138,6 +138,28 @@ test('test_tooling_design_tokens_test', async t => {
   await t.notThrowsAsync(syncTool.synchronizeTokensFromData(tokenDefinition, configDefinition.mapping, configDefinition.settings))
 })
 
+// ENG-870 - deep links in references combined with order
+test('test_tooling_design_tokens_chakra', async t => {
+  // Fetch specific design system version
+  let version = await testInstance.designSystemVersion(
+    process.env.TEST_DB_DESIGN_SYSTEM_ID,
+    process.env.TEST_DB_DESIGN_SYSTEM_VERSION_ID
+  )
+
+  // Path to file
+  let dataFilePath = path.join(process.cwd(), 'test-resources', 'figma-tokens', 'chakra-min')
+  let mappingFilePath = path.join(process.cwd(), 'test-resources', 'figma-tokens', 'chakra-min', 'supernova.settings.json')
+
+  // Get Figma Tokens synchronization tool
+  let syncTool = new SupernovaToolsDesignTokensPlugin(version)
+  let dataLoader = new FigmaTokensDataLoader()
+  let tokenDefinition = await dataLoader.loadTokensFromDirectory(dataFilePath, mappingFilePath)
+  let configDefinition = dataLoader.loadConfigFromPath(mappingFilePath)
+
+  // Run sync
+  await t.notThrowsAsync(syncTool.synchronizeTokensFromData(tokenDefinition, configDefinition.mapping, configDefinition.settings))
+})
+
 
 test('test_tooling_design_tokens_order', async t => {
   // Fetch specific design system version

--- a/test-resources/figma-tokens/chakra-min/$metadata.json
+++ b/test-resources/figma-tokens/chakra-min/$metadata.json
@@ -1,0 +1,8 @@
+{
+  "tokenSetOrder": [
+    "core/border",
+    "comp/button",
+    "comp/radio",
+    "default/light"
+  ]
+}

--- a/test-resources/figma-tokens/chakra-min/$themes.json
+++ b/test-resources/figma-tokens/chakra-min/$themes.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "079b44a8b28ed46aff5be1542d750aaa108d99e1",
+    "name": "light",
+    "selectedTokenSets": {
+      "comp/button": "enabled",
+      "core/border": "source",
+      "default/light": "enabled",
+      "comp/radio": "enabled"
+    },
+    "$figmaStyleReferences": {}
+  },
+  {
+    "id": "079b44a8b28ed46aff5be1542d750aaa108d88e1",
+    "name": "dark",
+    "selectedTokenSets": {
+      "comp/button": "enabled",
+      "core/border": "source",
+      "default/light": "enabled",
+      "comp/radio": "enabled"
+    },
+    "$figmaStyleReferences": {}
+  }
+]

--- a/test-resources/figma-tokens/chakra-min/comp/button.json
+++ b/test-resources/figma-tokens/chakra-min/comp/button.json
@@ -1,0 +1,16 @@
+{
+  "btn": {
+    "border-width": {
+      "value": "{default.border-width.actions}",
+      "type": "borderWidth"
+    }
+  },
+  "default": {
+    "border-width": {
+      "inputs": {
+        "value": "{border-width.1}",
+        "type": "borderWidth"
+      }
+    }
+  }
+}

--- a/test-resources/figma-tokens/chakra-min/comp/radio.json
+++ b/test-resources/figma-tokens/chakra-min/comp/radio.json
@@ -1,0 +1,10 @@
+{
+  "radio": {
+    "unselected": {
+      "border-width": {
+        "value": "{default.border-width.inputs}",
+        "type": "borderWidth"
+      }
+    }
+  }
+}

--- a/test-resources/figma-tokens/chakra-min/core/border.json
+++ b/test-resources/figma-tokens/chakra-min/core/border.json
@@ -1,0 +1,12 @@
+{
+  "border-width": {
+    "0": {
+      "value": "0",
+      "type": "borderWidth"
+    },
+    "1": {
+      "value": "1",
+      "type": "borderWidth"
+    }
+  }
+}

--- a/test-resources/figma-tokens/chakra-min/default/light.json
+++ b/test-resources/figma-tokens/chakra-min/default/light.json
@@ -1,0 +1,14 @@
+{
+  "default": {
+    "border-width": {
+      "actions": {
+        "value": "{border-width.1}",
+        "type": "borderWidth"
+      },
+      "inputs": {
+        "value": "{border-width.1}",
+        "type": "borderWidth"
+      }
+   }
+  }
+}

--- a/test-resources/figma-tokens/chakra-min/supernova.settings.json
+++ b/test-resources/figma-tokens/chakra-min/supernova.settings.json
@@ -1,0 +1,21 @@
+{
+    "mode": "multi-file",
+    "mapping": [
+      {
+        "tokensTheme": "light",
+        "supernovaBrand": "Default",
+        "supernovaTheme": null
+      },
+      {
+        "tokensTheme": "dark",
+        "supernovaBrand": "Default",
+        "supernovaTheme": "Dark theme"
+      }
+    ],
+    "settings": {
+      "dryRun": false,
+      "verbose": true,
+      "preciseCopy": true
+    }
+  }
+  


### PR DESCRIPTION
## Scenario

1. When there are several tokens with same path (say, `{default.border-width.inputs}`) 
2. And token order set is built in a way, that token `{radio.unselected.border-width}` references `{default.border-width.inputs}`
3. And token order set is built in a way, that after that new token with same path `{default.border-width.inputs}` is constructed
4. Then all the tokens still should have a valid `aliasTo` (before this PR `{radio.unselected.border-width}` had orphan `aliasTo`)

## Changes
- Replace references for such case in `addAtomicNode`