### PR TITLE
ENG-891: Keep same path tokens which defined later, whether they are resolved earlier or later

### DIFF
--- a/src/tests/Tooling/PluginFigmaTokens.spec.ts
+++ b/src/tests/Tooling/PluginFigmaTokens.spec.ts
@@ -273,7 +273,49 @@ test('test_tooling_design_tokens_prism', async t => {
   await t.notThrowsAsync(syncTool.synchronizeTokensFromData(tokenDefinition, configDefinition.mapping, configDefinition.settings))
 })
 
-test('test_tooling_design_tokens_order', async t => {
+// TODO: Add minimal test case data to reproduce
+test('test_tooling_design_tokens_elli', async t => {
+  // Fetch specific design system version
+  let version = await testInstance.designSystemVersion(
+    process.env.TEST_DB_DESIGN_SYSTEM_ID_EDIT,
+    process.env.TEST_DB_DESIGN_SYSTEM_VERSION_ID_EDIT
+  )
+
+  // Path to file
+  let dataFilePath = path.join(process.cwd(), 'test-resources', 'figma-tokens', 'elli-full', 'tokens')
+  let mappingFilePath = path.join(process.cwd(), 'test-resources', 'figma-tokens', 'elli-full', 'supernova.settings.json')
+
+  // Get Figma Tokens synchronization tool
+  let syncTool = new SupernovaToolsDesignTokensPlugin(version)
+  let dataLoader = new FigmaTokensDataLoader()
+  let tokenDefinition = await dataLoader.loadTokensFromDirectory(dataFilePath, mappingFilePath)
+  let configDefinition = dataLoader.loadConfigFromPath(mappingFilePath)
+
+  // Run sync
+  await syncTool.synchronizeTokensFromData(tokenDefinition, configDefinition.mapping, configDefinition.settings)
+
+  const validateDeepTokenRef = (tokens: Token[], description: string, hex: string, name: string) => {
+    const token = tokens.filter(t => t.description === description)[0] as ColorToken
+    t.true(!!token)
+    const ref = token.value.referencedToken as ColorToken;
+    t.true(!!ref)
+    t.is(token.value.hex, hex)
+    t.is(ref.value.hex, hex)
+
+    let d = 50
+    let c = token, r = ref
+    while (d-- > 0 && c && r) {
+      c = r
+      r = c?.value?.referencedToken as ColorToken
+    }
+
+    t.is(c.name, name)
+  }
+  const tokens = await version.tokens()
+  validateDeepTokenRef(tokens, 'Should be #00ff99ff', '00ff99ff', '300')
+})
+
+test('otest_tooling_design_tokens_order', async t => {
   // Fetch specific design system version
   let version = await testInstance.designSystemVersion(
     process.env.TEST_DB_DESIGN_SYSTEM_ID_EDIT,
@@ -301,19 +343,21 @@ test('test_tooling_design_tokens_order', async t => {
     syncTool.synchronizeTokensFromData(tokenDefinition, configDefinition.mapping, configDefinition.settings)
   )
 
-  const validateToken = (tokens: Token[], description: string, hex: string, name: string) => {
+  const validateToken = (tokens: Token[], description: string, hex: string, refDescription: string) => {
     const token = tokens.filter(t => t.description === description)[0] as ColorToken
-    t.true(!!token)
+    t.true(!!token, `Can't find ${description}`)
     const ref = tokens.filter(t => t.id === token.value.referencedToken.id)[0] as ColorToken
     t.true(!!ref)
     t.is(token.value.hex, hex)
     t.is(ref.value.hex, hex)
-    t.is(ref.name, name)
+    t.is(ref.description, refDescription)
   }
 
   const tokens = await version.tokens()
   validateToken(tokens, 'ocean-primary-default', '0000ffff', 'blue')
   validateToken(tokens, 'forest-primary-default', '00ff00ff', 'green')
+  validateToken(tokens, 'ocean-secondary-default', '00ff00ff', 'global-tertiary-default')
+  validateToken(tokens, 'ocean-quaternary-default', '00ff00ff', 'green')
 })
 
 // EPDA-167

--- a/src/tools/design-tokens/utilities/SDKDTJSONParser.ts
+++ b/src/tools/design-tokens/utilities/SDKDTJSONParser.ts
@@ -141,6 +141,9 @@ export class DTJSONParser {
 
         // Respect $metadata.json -> tokenSetOrder
         if (order.length) {
+          // We could have process tokens in reverse orders here, and do not replace tokens at all:
+          // i.e. trying to resolve higher priority tokens first and add them in DTTokenReferenceResolver
+          // but lower priority tokens still could be resolved earlier, so reverse sort order would not help.
           pairedSets.sort((a,b) => order.indexOf(a.name) - order.indexOf(b.name))
         }
 

--- a/test-resources/figma-tokens/token-order-sync/global.json
+++ b/test-resources/figma-tokens/token-order-sync/global.json
@@ -8,6 +8,27 @@
             "type": "color",
             "description": "global-primary-default"
           }
+        },
+        "secondary": {
+          "default": {
+            "value": "{ds.base.color.green}",
+            "type": "color",
+            "description": "global-secondary-default"
+          }
+        },
+        "tertiary": {
+          "default": {
+            "value": "{ds.base.color.green}",
+            "type": "color",
+            "description": "global-tertiary-default"
+          }
+        },
+        "quaternary": {
+          "default": {
+            "value": "#BBBBBB",
+            "type": "color",
+            "description": "global-quaternary-default"
+          }
         }
       }
     }

--- a/test-resources/figma-tokens/token-order-sync/ocean.json
+++ b/test-resources/figma-tokens/token-order-sync/ocean.json
@@ -8,6 +8,20 @@
             "type": "color",
             "description": "ocean-primary-default"
           }
+        },
+        "secondary": {
+          "default": {
+            "value": "{ds.sys.color.tertiary.default}",
+            "type": "color",
+            "description": "ocean-secondary-default"
+          }
+        },
+        "quaternary": {
+          "default": {
+            "value": "{ds.base.color.green}",
+            "type": "color",
+            "description": "ocean-quaternary-default"
+          }
         }
       }
     }


### PR DESCRIPTION
## Notes
 - Plugin using `last one wins` strategy, i.e. token with same path inside last defined set in `tokenSetOrder` should win (like `ocean` > `global`)
 - We process tokens in order from `$metadata.json`, and keeping theirs original index now (we process `global`, then `ocean`)
 - Any of token with same path could be resolved earlier (tokens from either `ocean` or `global` could be resolved first)
 - We should update tokens of same path that have higher priority only (if we resolved token from `ocean` already, we should not overwrite it with token same path from `global`, even if it was resolved later)
- Not replacing tokens would not work either, even if we process tokens in reversed order (higher priority first)

## Changes
 - Inside `DTTokenReferenceResolver.mappedTokens` we keep both Token and its original index
 - Inside `DTTokenReferenceResolver.addAtomicNode` during ref resolve we now update token in `mappedTokens` only for token with higher original index

## Example
`global.json`
```
"color": {
  "primary": {
    "default": {
      "value": "{ds.base.color.snow}",
      "type": "color",
      "description": "global-primary-default"
    }
  },
  "quaternary": {
    "default": {
      "value": "{ds.base.color.green}",
      "type": "color",
      "description": "global-quaternary-default"
    }
  }
}
```
`ocean.json` (last in `tokenSetOrder`)
```
"color": {
  "primary": {
    "default": {
      "value": "{ds.base.color.blue}",
      "type": "color",
      "description": "ocean-primary-default"
    }
  },
  "quaternary": {
    "default": {
      "value": "#BBBBBB",
      "type": "color",
      "description": "ocean-quaternary-default"
    }
  }
}
```

1. `ocean -> quaternary = #BBBBBB`
2. `global -> primary = #snow`
3. `ocean -> primary = #blue` (and we **should** replace already resolved `primary` token)
4.  `global -> quaternary = #green` (and we **should not** replace it, even if we resolved it later)