### PR TITLE
#token-studio - Fix filtering out theme to remove overrides if preciseCopy=true

### DIFF
--- a/src/tests/Tooling/PluginFigmaTokens.spec.ts
+++ b/src/tests/Tooling/PluginFigmaTokens.spec.ts
@@ -313,6 +313,10 @@ test('test_tooling_design_tokens_elli', async t => {
   }
   const tokens = await version.tokens()
   validateDeepTokenRef(tokens, 'Should be #00ff99ff', '00ff99ff', '300')
+
+  const themes = await version.themes()
+  const theme = themes.find(t => t.name === 'Elli Dark')
+  validateToken(t, theme.overriddenTokens, 'Should be #00ff99ff', '84ffb9ff')
 })
 
 test('test_tooling_design_tokens_order', async t => {

--- a/src/tools/design-tokens/SDKToolsDesignTokensPlugin.ts
+++ b/src/tools/design-tokens/SDKToolsDesignTokensPlugin.ts
@@ -149,7 +149,7 @@ export class SupernovaToolsDesignTokensPlugin {
     if (settings.preciseCopy) {
       const mapInSource = mapping.filter(m => !!m.bindToTheme).map(m => ({ brand: m.bindToBrand, theme: m.bindToTheme.toLowerCase().trim()}))
       const themesInSource = mapInSource.map(m => m.theme)
-      const themesToRemove = themes.filter(t => !themesInSource.includes(t.id.toLowerCase().trim()) || themesInSource.includes(t.name.toLowerCase().trim()))
+      const themesToRemove = themes.filter(t => !(themesInSource.includes(t.id.toLowerCase().trim()) || themesInSource.includes(t.name.toLowerCase().trim())))
       for (const themeToRemove of themesToRemove) {
         let brand = brands.find(b => b.persistentId === themeToRemove.brandId)
         await this.mergeThemeWithRemoteSource([], brand, themeToRemove, !settings.dryRun, settings.verbose, settings.preciseCopy)


### PR DESCRIPTION
## Changes
 - If `preciseCopy = true` we should remove all overrides for themes that were not passed in mappings
 - Fixes condition to filter out such themes