### PR TITLE
TS - Fixes for radii and typography

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@supernovaio/supernova-sdk",
-    "version": "1.8.68",
+    "version": "1.8.72",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@supernovaio/supernova-sdk",
-            "version": "1.8.68",
+            "version": "1.8.72",
             "license": "MIT",
             "dependencies": {
                 "abab": "^2.0.5",
@@ -15,6 +15,7 @@
                 "expr-eval": "^2.0.2",
                 "fuse.js": "^6.6.2",
                 "lodash": "~4.17.21",
+                "ml-matrix": "^6.10.4",
                 "node-fetch": "^2.6.9",
                 "parse-color": "^1.0.0",
                 "postcss-calc-ast-parser": "^0.1.4",
@@ -2920,6 +2921,11 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-any-array": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-2.0.0.tgz",
+            "integrity": "sha512-WdPV58rT3aOWXvvyuBydnCq4S2BM1Yz8shKxlEpk/6x+GX202XRvXOycEFtNgnHVLoc46hpexPFx8Pz1/sMS0w=="
+        },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4034,6 +4040,41 @@
             },
             "bin": {
                 "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/ml-array-max": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/ml-array-max/-/ml-array-max-1.2.4.tgz",
+            "integrity": "sha512-BlEeg80jI0tW6WaPyGxf5Sa4sqvcyY6lbSn5Vcv44lp1I2GR6AWojfUvLnGTNsIXrZ8uqWmo8VcG1WpkI2ONMQ==",
+            "dependencies": {
+                "is-any-array": "^2.0.0"
+            }
+        },
+        "node_modules/ml-array-min": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/ml-array-min/-/ml-array-min-1.2.3.tgz",
+            "integrity": "sha512-VcZ5f3VZ1iihtrGvgfh/q0XlMobG6GQ8FsNyQXD3T+IlstDv85g8kfV0xUG1QPRO/t21aukaJowDzMTc7j5V6Q==",
+            "dependencies": {
+                "is-any-array": "^2.0.0"
+            }
+        },
+        "node_modules/ml-array-rescale": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/ml-array-rescale/-/ml-array-rescale-1.3.7.tgz",
+            "integrity": "sha512-48NGChTouvEo9KBctDfHC3udWnQKNKEWN0ziELvY3KG25GR5cA8K8wNVzracsqSW1QEkAXjTNx+ycgAv06/1mQ==",
+            "dependencies": {
+                "is-any-array": "^2.0.0",
+                "ml-array-max": "^1.2.4",
+                "ml-array-min": "^1.2.3"
+            }
+        },
+        "node_modules/ml-matrix": {
+            "version": "6.10.4",
+            "resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.10.4.tgz",
+            "integrity": "sha512-rUyEhfNPzqFsltYwvjNeYQXlYEaVea3KgzcJKJteQUj2WVAGFx9fLNRjtMR9mg2B6bd5buxlmkZmxM4hmO+SKg==",
+            "dependencies": {
+                "is-any-array": "^2.0.0",
+                "ml-array-rescale": "^1.3.7"
             }
         },
         "node_modules/mount-point": {
@@ -9158,6 +9199,11 @@
             "integrity": "sha512-MVBLKUTangM3EfRPFROhmWQQKRDsrgI83J8GS3jXy+OwYqiR2/aoWndYQ5416jLE3uaGgLH7ncme3X9y09gZ3g==",
             "dev": true
         },
+        "is-any-array": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-2.0.0.tgz",
+            "integrity": "sha512-WdPV58rT3aOWXvvyuBydnCq4S2BM1Yz8shKxlEpk/6x+GX202XRvXOycEFtNgnHVLoc46hpexPFx8Pz1/sMS0w=="
+        },
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -9947,6 +9993,41 @@
             "dev": true,
             "requires": {
                 "minimist": "^1.2.5"
+            }
+        },
+        "ml-array-max": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/ml-array-max/-/ml-array-max-1.2.4.tgz",
+            "integrity": "sha512-BlEeg80jI0tW6WaPyGxf5Sa4sqvcyY6lbSn5Vcv44lp1I2GR6AWojfUvLnGTNsIXrZ8uqWmo8VcG1WpkI2ONMQ==",
+            "requires": {
+                "is-any-array": "^2.0.0"
+            }
+        },
+        "ml-array-min": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/ml-array-min/-/ml-array-min-1.2.3.tgz",
+            "integrity": "sha512-VcZ5f3VZ1iihtrGvgfh/q0XlMobG6GQ8FsNyQXD3T+IlstDv85g8kfV0xUG1QPRO/t21aukaJowDzMTc7j5V6Q==",
+            "requires": {
+                "is-any-array": "^2.0.0"
+            }
+        },
+        "ml-array-rescale": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/ml-array-rescale/-/ml-array-rescale-1.3.7.tgz",
+            "integrity": "sha512-48NGChTouvEo9KBctDfHC3udWnQKNKEWN0ziELvY3KG25GR5cA8K8wNVzracsqSW1QEkAXjTNx+ycgAv06/1mQ==",
+            "requires": {
+                "is-any-array": "^2.0.0",
+                "ml-array-max": "^1.2.4",
+                "ml-array-min": "^1.2.3"
+            }
+        },
+        "ml-matrix": {
+            "version": "6.10.4",
+            "resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.10.4.tgz",
+            "integrity": "sha512-rUyEhfNPzqFsltYwvjNeYQXlYEaVea3KgzcJKJteQUj2WVAGFx9fLNRjtMR9mg2B6bd5buxlmkZmxM4hmO+SKg==",
+            "requires": {
+                "is-any-array": "^2.0.0",
+                "ml-array-rescale": "^1.3.7"
             }
         },
         "mount-point": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "expr-eval": "^2.0.2",
         "fuse.js": "^6.6.2",
         "lodash": "~4.17.21",
+        "ml-matrix": "^6.10.4",
         "node-fetch": "^2.6.9",
         "parse-color": "^1.0.0",
         "postcss-calc-ast-parser": "^0.1.4",

--- a/src/model/tokens/SDKBorderToken.ts
+++ b/src/model/tokens/SDKBorderToken.ts
@@ -47,7 +47,6 @@ export class BorderToken extends Token {
     }
   }
 
-
   static create(
     version: DesignSystemVersion,
     brand: Brand,
@@ -97,22 +96,17 @@ export class BorderToken extends Token {
       } else {
         // Empty definition needs to fallback to proper SN definition - make it transparent shadow with 0 0 0 0 values
         definition = {
-          color: "rgba(0,0,0,0)",
-          position: "outside", 
+          color: 'rgba(0,0,0,0)',
+          position: 'outside',
           width: 0,
-          type: "border"
+          type: 'border'
         }
       }
     }
 
-    if (
-      !definition.hasOwnProperty('color') ||
-      !definition.hasOwnProperty('width')
-    ) {
+    if (!definition.hasOwnProperty('color') || !definition.hasOwnProperty('width')) {
       throw SupernovaError.fromSDKError(
-        `Border definition is missing one of required properties (color, width), was ${JSON.stringify(
-          definition
-        )}`
+        `Border definition is missing one of required properties (color, width), was ${JSON.stringify(definition)}`
       )
     }
 
@@ -124,13 +118,31 @@ export class BorderToken extends Token {
     // TODO: Position, style
 
     if (value.color === undefined) {
-      throw new Error(`Unable to resolve value 'color' for border token definition \n${JSON.stringify(definition, null, 2)}\n Did you possibly use incorrect reference?`)
+      throw new Error(
+        `Unable to resolve value 'color' for border token definition \n${JSON.stringify(
+          definition,
+          null,
+          2
+        )}\n Did you possibly use incorrect reference?`
+      )
     }
     if (value.position === undefined) {
-      throw new Error(`Unable to resolve value 'position' for border token definition \n${JSON.stringify(definition, null, 2)}\n Did you possibly use incorrect reference?`)
+      throw new Error(
+        `Unable to resolve value 'position' for border token definition \n${JSON.stringify(
+          definition,
+          null,
+          2
+        )}\n Did you possibly use incorrect reference?`
+      )
     }
     if (value.width === undefined) {
-      throw new Error(`Unable to resolve value 'width' for border token definition \n${JSON.stringify(definition, null, 2)}\n Did you possibly use incorrect reference?`)
+      throw new Error(
+        `Unable to resolve value 'width' for border token definition \n${JSON.stringify(
+          definition,
+          null,
+          2
+        )}\n Did you possibly use incorrect reference?`
+      )
     }
 
     return value
@@ -148,24 +160,24 @@ export class BorderToken extends Token {
 
   static valueToWriteObject(value: BorderTokenValue): { aliasTo: string | undefined; value: BorderTokenRemoteValue } {
     let valueObject = !value.referencedToken
-    ? {
-        color: {
-          aliasTo: value.color.referencedToken ? value.color.referencedToken.id : undefined,
-          value: value.color.referencedToken ? null : value.color.hex
-        },
-        width: {
-          aliasTo: value.width.referencedToken ? value.width.referencedToken.id : undefined,
-          value: value.width.referencedToken
-            ? null
-            : {
-                measure: value.width.measure,
-                unit: value.width.unit
-              }
-        },
-        position: value.position,
-        isEnabled: true
-      }
-    : undefined
+      ? {
+          color: {
+            aliasTo: value.color.referencedToken ? value.color.referencedToken.id : undefined,
+            value: value.color.referencedToken ? null : ColorToken.normalizedHex(value.color.hex)
+          },
+          width: {
+            aliasTo: value.width.referencedToken ? value.width.referencedToken.id : undefined,
+            value: value.width.referencedToken
+              ? null
+              : {
+                  measure: value.width.measure,
+                  unit: value.width.unit
+                }
+          },
+          position: value.position,
+          isEnabled: true
+        }
+      : undefined
     return {
       aliasTo: value.referencedToken ? value.referencedToken.id : undefined,
       value: valueObject

--- a/src/model/tokens/SDKColorToken.ts
+++ b/src/model/tokens/SDKColorToken.ts
@@ -99,7 +99,6 @@ export class ColorToken extends Token {
   }
 
   static colorValueFromDefinition(definition: string): ColorTokenValue {
-
     let normalizedDefinition = this.normalizeColor(definition)
     let result = parseColor(normalizedDefinition)
     if (!result || result.hex === undefined) {
@@ -161,7 +160,9 @@ export class ColorToken extends Token {
           })
         }
       } catch (e) {
-        throw new Error(`Unable to parse provided color '${color}'. Supported formats are: \nrgb(r <number>, g <number>, b <number>)\nrgba(r <number>, g <number>, b <number>, a <number | percentage>\nhsl(h <number>, s <percentage>, l <percentage>>\nhsla(h <number>, s <percentage>, l <percentage>, a <number | percentage>\nred | blue | black ...)`)
+        throw new Error(
+          `Unable to parse provided color '${color}'. Supported formats are: \nrgb(r <number>, g <number>, b <number>)\nrgba(r <number>, g <number>, b <number>, a <number | percentage>\nhsl(h <number>, s <percentage>, l <percentage>>\nhsla(h <number>, s <percentage>, l <percentage>, a <number | percentage>\nred | blue | black ...)`
+        )
       }
       return returnedColor
     } catch (e) {
@@ -176,6 +177,16 @@ export class ColorToken extends Token {
       return Number(matched[0].slice(0, -1)) / 100
     }
     return Number(value)
+  }
+
+  static normalizedHex(value: string | null): string | null {
+    if (!value) {
+      return null
+    }
+    if (value.startsWith('#')) {
+      return value
+    }
+    return `#${value}`
   }
 
   static colorValueFromDefinitionOrReference(
@@ -229,7 +240,7 @@ export class ColorToken extends Token {
   }
 
   static valueToWriteObject(value: ColorTokenValue): { aliasTo: string | undefined; value: ColorTokenRemoteValue } {
-    let valueObject = !value.referencedToken ? (value.hex.startsWith('#') ? value.hex : `#${value.hex}`) : undefined
+    let valueObject = !value.referencedToken ? ColorToken.normalizedHex(value.hex) : undefined
     return {
       aliasTo: value.referencedToken ? value.referencedToken.id : undefined,
       value: valueObject

--- a/src/model/tokens/SDKGradientToken.ts
+++ b/src/model/tokens/SDKGradientToken.ts
@@ -9,13 +9,23 @@
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 // MARK: - Imports
 
-import { ElementProperty } from '../..'
+import {
+  Brand,
+  ColorToken,
+  ElementProperty,
+  GradientTokenValue,
+  GradientStopValue,
+  GradientType,
+  TokenType
+} from '../..'
 import { DesignSystemVersion } from '../../core/SDKDesignSystemVersion'
 import { ElementPropertyValue } from '../elements/values/SDKElementPropertyValue'
 import { GradientTokenRemoteModel, TokenRemoteModel } from './remote/SDKRemoteTokenModel'
-import { GradientTokenRemoteValue } from './remote/SDKRemoteTokenValue'
 import { Token } from './SDKToken'
-import { GradientTokenValue } from './SDKTokenValue'
+import { v4 as uuidv4 } from 'uuid'
+import { DTTokenReferenceResolver } from '../../tools/design-tokens/utilities/SDKDTTokenReferenceResolver'
+import { Matrix, inverse } from 'ml-matrix'
+import { GradientTokenRemoteValue } from './remote/SDKRemoteTokenValue'
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 // MARK: -  Object Definition
@@ -50,6 +60,176 @@ export class GradientToken extends Token {
   }
 
   // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
+  // MARK: - Static building
+
+  static create(
+    version: DesignSystemVersion,
+    brand: Brand,
+    name: string,
+    description: string,
+    value: string,
+    alias: GradientToken | null,
+    referenceResolver: DTTokenReferenceResolver,
+    properties: Array<ElementProperty>,
+    propertyValues: Array<ElementPropertyValue>
+  ): GradientToken {
+    let baseToken: TokenRemoteModel = {
+      id: undefined, // Ommited id will create new token
+      persistentId: uuidv4(),
+      brandId: brand.persistentId,
+      designSystemVersionId: version.id,
+      type: TokenType.gradient,
+      meta: {
+        name: name,
+        description: description
+      },
+      data: {},
+      customPropertyOverrides: []
+    }
+
+    if (value) {
+      // Raw value
+      let tokenValue = this.gradientValueFromDefinition(value, referenceResolver)
+      return new GradientToken(version, baseToken, tokenValue, undefined, properties, propertyValues)
+    } else if (alias) {
+      // Aliased value - copy and create raw from reference
+      let tokenValue: GradientTokenValue = {
+        to: {
+          x: alias.value.to.x,
+          y: alias.value.to.y
+        },
+        from: {
+          x: alias.value.from.x,
+          y: alias.value.from.y
+        },
+        type: alias.value.type,
+        aspectRatio: alias.value.aspectRatio,
+        stops: alias.value.stops,
+        referencedToken: alias
+      }
+      return new GradientToken(version, baseToken, tokenValue, undefined, properties, propertyValues)
+    }
+  }
+
+  static gradientValueFromDefinition(
+    definition: string,
+    referenceResolver: DTTokenReferenceResolver
+  ): GradientTokenValue {
+    // Parse raw gradient pieces
+    const [gradientDegrees, ...colorStops] = definition
+      .substring(definition.indexOf('(') + 1, definition.lastIndexOf(')'))
+      .split(', ')
+
+    // Rotate 90 degrees
+    const degreesAsNumber = parseFloat(gradientDegrees.split('deg').join(''))
+    const degrees = -(degreesAsNumber - 90)
+    const rad = degrees * (Math.PI / 180)
+    const scale = degreesAsNumber % 90 === 0 ? 1 : Math.sqrt(1 + Math.tan(degreesAsNumber * (Math.PI / 180)) ** 2)
+
+    // Build transformation matrix so we can figure out the proper sizing of the gradient in 2d space
+    const matrix = inverse(
+      new Matrix([
+        [1, 0, 0.5],
+        [0, 1, 0.5],
+        [0, 0, 1]
+      ])
+        .mmul(
+          new Matrix([
+            [Math.cos(rad), Math.sin(rad), 0],
+            [-Math.sin(rad), Math.cos(rad), 0],
+            [0, 0, 1]
+          ])
+        )
+        .mmul(
+          new Matrix([
+            [scale, 0, 0],
+            [0, scale, 0],
+            [0, 0, 1]
+          ])
+        )
+        .mmul(
+          new Matrix([
+            [1, 0, -0.5],
+            [0, 1, -0.5],
+            [0, 0, 1]
+          ])
+        )
+    ).to2DArray()
+
+    // Build gradient stops
+    const gradientStops: Array<GradientStopValue> = colorStops.map((s, index) => {
+      const separatedStop = s.split(' ')
+      const colorValue = ColorToken.colorValueFromDefinitionOrReference(separatedStop[0], referenceResolver)
+      return {
+        color: colorValue,
+        position: parseFloat(separatedStop[1]) / 100
+      }
+    })
+
+    // Construct gradient value by using
+    return {
+      from: {
+        x: matrix[0][0],
+        y: matrix[0][1]
+      },
+      to: {
+        x: matrix[1][0],
+        y: matrix[1][1]
+      },
+      type: GradientType.linear,
+      aspectRatio: 1,
+      stops: gradientStops,
+      referencedToken: null
+    }
+  }
+
+  static gradientValueFromDefinitionOrReference(
+    definition: any,
+    referenceResolver: DTTokenReferenceResolver
+  ): GradientTokenValue | undefined {
+    if (referenceResolver.valueHasReference(definition)) {
+      if (!referenceResolver.isBalancedReference(definition)) {
+        // Internal syntax of reference corrupted
+        throw new Error(`Invalid reference syntax in token value: ${definition}`)
+      }
+      if (referenceResolver.valueIsPureReference(definition)) {
+        // When color is pure reference, we can immediately resolve it
+        let reference = referenceResolver.lookupReferencedToken(definition) as GradientToken
+        if (!reference) {
+          return undefined
+        }
+        return {
+          referencedToken: reference,
+          to: {
+            x: reference.value.to.x,
+            y: reference.value.to.y
+          },
+          from: {
+            x: reference.value.from.x,
+            y: reference.value.from.y
+          },
+          type: reference.value.type,
+          aspectRatio: reference.value.aspectRatio,
+          stops: reference.value.stops
+        }
+      } else {
+        // When color is not a pure reference, we must resolve it further before we can resolve it
+        let references = referenceResolver.lookupAllReferencedTokens(definition)
+        if (!references) {
+          // Still unable to solve the reference, continue looking in some other tokens
+          return undefined
+        } else {
+          // Resolved all internal references
+          let resolvedValue = referenceResolver.replaceAllReferencedTokens(definition, references)
+          return this.gradientValueFromDefinition(resolvedValue, referenceResolver)
+        }
+      }
+    } else {
+      return this.gradientValueFromDefinition(definition, referenceResolver)
+    }
+  }
+
+  // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
   // MARK: - Writing
 
   toWriteObject(): GradientTokenRemoteModel {
@@ -79,7 +259,7 @@ export class GradientToken extends Token {
               position: s.position,
               color: {
                 aliasTo: s.color.referencedToken ? s.color.referencedToken.id : undefined,
-                value: s.color.referencedToken ? null : s.color.hex
+                value: s.color.referencedToken ? null : ColorToken.normalizedHex(s.color.hex)
               }
             }
           })

--- a/src/model/tokens/SDKRadiusToken.ts
+++ b/src/model/tokens/SDKRadiusToken.ts
@@ -54,7 +54,7 @@ export class RadiusToken extends Token {
     name: string,
     description: string,
     value: string,
-    alias: RadiusToken | null,
+    alias: RadiusToken | MeasureToken | null,
     properties: Array<ElementProperty>,
     propertyValues: Array<ElementPropertyValue>
   ): RadiusToken {
@@ -77,49 +77,67 @@ export class RadiusToken extends Token {
       let tokenValue = this.radiusValueFromDefinition(value)
       return new RadiusToken(version, baseToken, tokenValue, undefined, properties, propertyValues)
     } else if (alias) {
-      // Aliased value - copy and create raw from reference
-      let tokenValue: RadiusTokenValue = {
-        radius: {
-          unit: alias.value.radius.unit,
-          measure: alias.value.radius.measure,
-          referencedToken: undefined
-        },
-        topLeft: alias.value.topLeft
-          ? {
-              unit: alias.value.topLeft.unit,
-              measure: alias.value.topLeft.measure,
-              referencedToken: undefined
-            }
-          : null,
-        topRight: alias.value.topRight
-          ? {
-              unit: alias.value.topRight.unit,
-              measure: alias.value.topRight.measure,
-              referencedToken: undefined
-            }
-          : null,
-        bottomLeft: alias.value.bottomLeft
-          ? {
-              unit: alias.value.bottomLeft.unit,
-              measure: alias.value.bottomLeft.measure,
-              referencedToken: undefined
-            }
-          : null,
-        bottomRight: alias.value.bottomRight
-          ? {
-              unit: alias.value.bottomRight.unit,
-              measure: alias.value.bottomRight.measure,
-              referencedToken: undefined
-            }
-          : null,
-        referencedToken: alias
+      if (alias instanceof MeasureToken) {
+        // If measure token was referenced, create raw value of radius token from it and discard the reference to at least it gets imported
+        let tokenValue: RadiusTokenValue = {
+          radius: {
+            unit: alias.value.unit,
+            measure: alias.value.measure,
+            referencedToken: undefined
+          },
+          topLeft: null,
+          topRight: null,
+          bottomLeft: null,
+          bottomRight: null,
+          referencedToken: null
+        }
+        return new RadiusToken(version, baseToken, tokenValue, undefined, properties, propertyValues)
+      } else {
+        // Aliased value - copy and create raw from reference
+        let tokenValue: RadiusTokenValue = {
+          radius: {
+            unit: alias.value.radius.unit,
+            measure: alias.value.radius.measure,
+            referencedToken: undefined
+          },
+          topLeft: alias.value.topLeft
+            ? {
+                unit: alias.value.topLeft.unit,
+                measure: alias.value.topLeft.measure,
+                referencedToken: undefined
+              }
+            : null,
+          topRight: alias.value.topRight
+            ? {
+                unit: alias.value.topRight.unit,
+                measure: alias.value.topRight.measure,
+                referencedToken: undefined
+              }
+            : null,
+          bottomLeft: alias.value.bottomLeft
+            ? {
+                unit: alias.value.bottomLeft.unit,
+                measure: alias.value.bottomLeft.measure,
+                referencedToken: undefined
+              }
+            : null,
+          bottomRight: alias.value.bottomRight
+            ? {
+                unit: alias.value.bottomRight.unit,
+                measure: alias.value.bottomRight.measure,
+                referencedToken: undefined
+              }
+            : null,
+          referencedToken: alias
+        }
+        return new RadiusToken(version, baseToken, tokenValue, undefined, properties, propertyValues)
       }
-      return new RadiusToken(version, baseToken, tokenValue, undefined, properties, propertyValues)
+      // Handle references to aliases
     }
   }
 
   static radiusValueFromDefinition(definition: string | number): RadiusTokenValue {
-    if (typeof definition === "number") {
+    if (typeof definition === 'number') {
       return {
         radius: MeasureToken.measureValueFromDefinition(definition),
         topLeft: null,
@@ -178,51 +196,61 @@ export class RadiusToken extends Token {
     let valueObject = !value.referencedToken
       ? {
           radius: {
-            aliasTo: undefined,
-            value: {
-              measure: value.radius.measure,
-              unit: value.radius.unit
-            }
+            aliasTo: value.radius.referencedToken ? value.radius.referencedToken.id : undefined,
+            value: value.radius.referencedToken
+              ? null
+              : {
+                  measure: value.radius.measure,
+                  unit: value.radius.unit
+                }
           },
           topLeft: value.topLeft
             ? {
-                aliasTo: undefined,
-                value: {
-                  measure: value.topLeft.measure,
-                  unit: value.topLeft.unit
-                }
+                aliasTo: value.topLeft.referencedToken ? value.topLeft.referencedToken.id : undefined,
+                value: value.topLeft.referencedToken
+                  ? null
+                  : {
+                      measure: value.topLeft.measure,
+                      unit: value.topLeft.unit
+                    }
               }
             : null,
           topRight: value.topRight
             ? {
-                aliasTo: undefined,
-                value: {
-                  measure: value.topRight.measure,
-                  unit: value.topRight.unit
-                }
+                aliasTo: value.topRight.referencedToken ? value.topRight.referencedToken.id : undefined,
+                value: value.topRight.referencedToken
+                  ? null
+                  : {
+                      measure: value.topRight.measure,
+                      unit: value.topRight.unit
+                    }
               }
             : null,
           bottomLeft: value.bottomLeft
             ? {
-                aliasTo: undefined,
-                value: {
-                  measure: value.bottomLeft.measure,
-                  unit: value.bottomLeft.unit
-                }
+                aliasTo: value.bottomLeft.referencedToken ? value.bottomLeft.referencedToken.id : undefined,
+                value: value.bottomLeft.referencedToken
+                  ? null
+                  : {
+                      measure: value.bottomLeft.measure,
+                      unit: value.bottomLeft.unit
+                    }
               }
             : null,
           bottomRight: value.bottomRight
             ? {
-                aliasTo: undefined,
-                value: {
-                  measure: value.bottomRight.measure,
-                  unit: value.bottomRight.unit
-                }
+                aliasTo: value.bottomRight.referencedToken ? value.bottomRight.referencedToken.id : undefined,
+                value: value.bottomRight.referencedToken
+                  ? null
+                  : {
+                      measure: value.bottomRight.measure,
+                      unit: value.bottomRight.unit
+                    }
               }
             : null
         }
       : undefined
-      
+
     return {
       aliasTo: value.referencedToken ? value.referencedToken.id : undefined,
       value: valueObject

--- a/src/model/tokens/SDKShadowToken.ts
+++ b/src/model/tokens/SDKShadowToken.ts
@@ -217,11 +217,7 @@ export class ShadowToken extends Token {
       ? {
           color: {
             aliasTo: value.color.referencedToken ? value.color.referencedToken.id : undefined,
-            value: value.color.referencedToken
-              ? null
-              : value.color.hex.startsWith('#')
-              ? value.color.hex
-              : `#${value.color.hex}`
+            value: value.color.referencedToken ? null : ColorToken.normalizedHex(value.color.hex)
           },
           isEnabled: true,
           x: {

--- a/src/model/tokens/SDKTypographyToken.ts
+++ b/src/model/tokens/SDKTypographyToken.ts
@@ -214,15 +214,17 @@ export class TypographyToken extends Token {
                   unit: value.paragraphSpacing.unit
                 }
           },
-          lineHeight: {
-            aliasTo: value.lineHeight.referencedToken ? value.lineHeight.referencedToken.id : undefined,
-            value: value.lineHeight.referencedToken
-              ? null
-              : {
-                  measure: value.lineHeight.measure,
-                  unit: value.lineHeight.unit
-                }
-          },
+          lineHeight: value.lineHeight
+            ? {
+                aliasTo: value.lineHeight.referencedToken ? value.lineHeight.referencedToken.id : undefined,
+                value: value.lineHeight.referencedToken
+                  ? null
+                  : {
+                      measure: value.lineHeight.measure,
+                      unit: value.lineHeight.unit
+                    }
+              }
+            : null,
           textCase: value.textCase,
           textDecoration: value.textDecoration
         }

--- a/src/tools/design-tokens/utilities/SDKDTJSONConverter.ts
+++ b/src/tools/design-tokens/utilities/SDKDTJSONConverter.ts
@@ -65,6 +65,7 @@ export class DTJSONConverter {
   // MARK: - Token Conversion
 
   convertNodesToTokens(nodes: Array<DTParsedNode>, brand: Brand): Array<DTProcessedTokenNode> {
+    console.log('1')
     // Compute measures first. Measures can be used to do all types of calculation, so they must be available at the beginning for all other types of tokens
     this.convertNodesToTokensForSupportedNodeTypes(
       [
@@ -86,28 +87,36 @@ export class DTJSONConverter {
     // Other tokens
     // this.convertNodesToTokensForSupportedNodeTypes(['other'], nodes, brand)
 
+    console.log('2')
     // Color tokens
     this.convertNodesToTokensForSupportedNodeTypes(['color'], nodes, brand)
 
+    console.log('3')
     // Radii tokens
     this.convertNodesToTokensForSupportedNodeTypes(['borderRadius'], nodes, brand)
 
+    console.log('4')
     // Shadow tokens
     this.convertNodesToTokensForSupportedNodeTypes(['boxShadow'], nodes, brand)
 
+    console.log('5')
     // Gradient tokens
     this.convertNodesToTokensForSupportedNodeTypes(['gradient'], nodes, brand)
 
+    console.log('6')
     // Typography tokens
     this.convertNodesToTokensForSupportedNodeTypes(['typography'], nodes, brand)
 
+    console.log('7')
     // Border tokens
     this.convertNodesToTokensForSupportedNodeTypes(['border'], nodes, brand)
 
+    console.log('8')
     // Fix nodes so they are aligned with the way Supernova expects root groups to be named
     let processedNodes = this.referenceResolver.unmappedValues()
     this.remapRootNodeKeys(processedNodes)
 
+    console.log('5')
     // Retrieve all tokens
     return processedNodes
   }

--- a/src/tools/design-tokens/utilities/SDKDTJSONConverter.ts
+++ b/src/tools/design-tokens/utilities/SDKDTJSONConverter.ts
@@ -65,7 +65,6 @@ export class DTJSONConverter {
   // MARK: - Token Conversion
 
   convertNodesToTokens(nodes: Array<DTParsedNode>, brand: Brand): Array<DTProcessedTokenNode> {
-    console.log('1')
     // Compute measures first. Measures can be used to do all types of calculation, so they must be available at the beginning for all other types of tokens
     this.convertNodesToTokensForSupportedNodeTypes(
       [
@@ -87,36 +86,28 @@ export class DTJSONConverter {
     // Other tokens
     // this.convertNodesToTokensForSupportedNodeTypes(['other'], nodes, brand)
 
-    console.log('2')
     // Color tokens
     this.convertNodesToTokensForSupportedNodeTypes(['color'], nodes, brand)
 
-    console.log('3')
     // Radii tokens
     this.convertNodesToTokensForSupportedNodeTypes(['borderRadius'], nodes, brand)
 
-    console.log('4')
     // Shadow tokens
     this.convertNodesToTokensForSupportedNodeTypes(['boxShadow'], nodes, brand)
 
-    console.log('5')
     // Gradient tokens
     this.convertNodesToTokensForSupportedNodeTypes(['gradient'], nodes, brand)
 
-    console.log('6')
     // Typography tokens
     this.convertNodesToTokensForSupportedNodeTypes(['typography'], nodes, brand)
 
-    console.log('7')
     // Border tokens
     this.convertNodesToTokensForSupportedNodeTypes(['border'], nodes, brand)
 
-    console.log('8')
     // Fix nodes so they are aligned with the way Supernova expects root groups to be named
     let processedNodes = this.referenceResolver.unmappedValues()
     this.remapRootNodeKeys(processedNodes)
 
-    console.log('5')
     // Retrieve all tokens
     return processedNodes
   }
@@ -255,7 +246,6 @@ export class DTJSONConverter {
       unprocessedTokens = unprocessedDepthTokens
       depth += 1
       if (depth > maximumDepth) {
-        console.log(unprocessedTokens)
         throw new Error(
           `Engine was not able to solve references for the following tokens in a reasonable time: \n\n${unprocessedTokens
             .map(([t, i]) => DTTokenMerger.buildKey(t.path, t.name))

--- a/test-resources/figma-tokens/single-file-sync-using-names/tokens.json
+++ b/test-resources/figma-tokens/single-file-sync-using-names/tokens.json
@@ -97,6 +97,10 @@
                 "value": "#ffffff",
                 "type": "color"
             },
+            "gradient": {
+                "value": "linear-gradient(90deg, {colors.black} 0%, {colors.white} 100%)",
+                "type": "color"
+            },
             "gray": {
                 "100": {
                     "value": "#f7fafc",

--- a/test-resources/figma-tokens/single-file-sync/tokens.json
+++ b/test-resources/figma-tokens/single-file-sync/tokens.json
@@ -1,847 +1,849 @@
 {
-  "global": {
-    "spacing": {
-      "scale": {
-        "value": "2",
-        "type": "spacing"
-      },
-      "xs": {
-        "value": "4",
-        "type": "spacing"
-      },
-      "sm": {
-        "value": "{spacing.xs} * {spacing.scale}",
-        "type": "spacing"
-      },
-      "md": {
-        "value": "{spacing.sm} * {spacing.scale}",
-        "type": "spacing"
-      },
-      "lg": {
-        "value": "{spacing.md} * {spacing.scale}",
-        "type": "spacing"
-      },
-      "xl": {
-        "value": "{spacing.lg} * {spacing.scale}",
-        "type": "spacing"
-      }
+    "global": {
+        "spacing": {
+            "scale": {
+                "value": "2",
+                "type": "spacing"
+            },
+            "xs": {
+                "value": "4",
+                "type": "spacing"
+            },
+            "sm": {
+                "value": "{spacing.xs} * {spacing.scale}",
+                "type": "spacing"
+            },
+            "md": {
+                "value": "{spacing.sm} * {spacing.scale}",
+                "type": "spacing"
+            },
+            "lg": {
+                "value": "{spacing.md} * {spacing.scale}",
+                "type": "spacing"
+            },
+            "xl": {
+                "value": "{spacing.lg} * {spacing.scale}",
+                "type": "spacing"
+            }
+        },
+        "sizing": {
+            "scale": {
+                "value": "1.5",
+                "type": "sizing"
+            },
+            "xs": {
+                "value": "4",
+                "type": "sizing"
+            },
+            "sm": {
+                "value": "{sizing.xs} * {sizing.scale}",
+                "type": "sizing"
+            },
+            "md": {
+                "value": "{sizing.sm} * {sizing.scale}",
+                "type": "sizing"
+            },
+            "lg": {
+                "value": "{sizing.md} * {sizing.scale}",
+                "type": "sizing"
+            },
+            "xl": {
+                "value": "{sizing.lg} * {sizing.scale}",
+                "type": "sizing"
+            }
+        },
+        "borderRadius": {
+            "sm": {
+                "value": "4",
+                "type": "borderRadius"
+            },
+            "lg": {
+                "value": "8",
+                "type": "borderRadius"
+            },
+            "xl": {
+                "value": "16",
+                "type": "borderRadius"
+            }
+        },
+        "borderWidth": {
+            "none": {
+                "value": "0",
+                "type": "borderWidth"
+            },
+            "xs": {
+                "value": "1",
+                "type": "borderWidth"
+            },
+            "sm": {
+                "value": "2",
+                "type": "borderWidth"
+            },
+            "md": {
+                "value": "4",
+                "type": "borderWidth"
+            },
+            "lg": {
+                "value": "8",
+                "type": "borderWidth"
+            }
+        },
+        "colors": {
+            "black": {
+                "value": "#000000",
+                "type": "color"
+            },
+            "white": {
+                "value": "#ffffff",
+                "type": "color"
+            },
+            "gradient": {
+                "value": "linear-gradient(90deg, {colors.black} 0%, {colors.white} 100%)",
+                "type": "color"
+            },
+            "gray": {
+                "100": {
+                    "value": "#f7fafc",
+                    "type": "color"
+                },
+                "200": {
+                    "value": "#edf2f7",
+                    "type": "color"
+                },
+                "300": {
+                    "value": "#e2e8f0",
+                    "type": "color"
+                },
+                "400": {
+                    "value": "#cbd5e0",
+                    "type": "color"
+                },
+                "500": {
+                    "value": "#a0aec0",
+                    "type": "color"
+                },
+                "600": {
+                    "value": "#718096",
+                    "type": "color"
+                },
+                "700": {
+                    "value": "#4a5568",
+                    "type": "color"
+                },
+                "800": {
+                    "value": "#2d3748",
+                    "type": "color"
+                },
+                "900": {
+                    "value": "#1a202c",
+                    "type": "color"
+                }
+            },
+            "red": {
+                "100": {
+                    "value": "#fff5f5",
+                    "type": "color"
+                },
+                "200": {
+                    "value": "#fed7d7",
+                    "type": "color"
+                },
+                "300": {
+                    "value": "#feb2b2",
+                    "type": "color"
+                },
+                "400": {
+                    "value": "#fc8181",
+                    "type": "color"
+                },
+                "500": {
+                    "value": "#f56565",
+                    "type": "color"
+                },
+                "600": {
+                    "value": "#e53e3e",
+                    "type": "color"
+                },
+                "700": {
+                    "value": "#c53030",
+                    "type": "color"
+                },
+                "800": {
+                    "value": "#9b2c2c",
+                    "type": "color"
+                },
+                "900": {
+                    "value": "#742a2a",
+                    "type": "color"
+                }
+            },
+            "orange": {
+                "100": {
+                    "value": "#fffaf0",
+                    "type": "color"
+                },
+                "200": {
+                    "value": "#feebc8",
+                    "type": "color"
+                },
+                "300": {
+                    "value": "#fbd38d",
+                    "type": "color"
+                },
+                "400": {
+                    "value": "#f6ad55",
+                    "type": "color"
+                },
+                "500": {
+                    "value": "#ed8936",
+                    "type": "color"
+                },
+                "600": {
+                    "value": "#dd6b20",
+                    "type": "color"
+                },
+                "700": {
+                    "value": "#c05621",
+                    "type": "color"
+                },
+                "800": {
+                    "value": "#9c4221",
+                    "type": "color"
+                },
+                "900": {
+                    "value": "#7b341e",
+                    "type": "color"
+                }
+            },
+            "yellow": {
+                "100": {
+                    "value": "#fffff0",
+                    "type": "color"
+                },
+                "200": {
+                    "value": "#fefcbf",
+                    "type": "color"
+                },
+                "300": {
+                    "value": "#faf089",
+                    "type": "color"
+                },
+                "400": {
+                    "value": "#f6e05e",
+                    "type": "color"
+                },
+                "500": {
+                    "value": "#ecc94b",
+                    "type": "color"
+                },
+                "600": {
+                    "value": "#d69e2e",
+                    "type": "color"
+                },
+                "700": {
+                    "value": "#b7791f",
+                    "type": "color"
+                },
+                "800": {
+                    "value": "#975a16",
+                    "type": "color"
+                },
+                "900": {
+                    "value": "#744210",
+                    "type": "color"
+                }
+            },
+            "green": {
+                "100": {
+                    "value": "#f0fff4",
+                    "type": "color"
+                },
+                "200": {
+                    "value": "#c6f6d5",
+                    "type": "color"
+                },
+                "300": {
+                    "value": "#9ae6b4",
+                    "type": "color"
+                },
+                "400": {
+                    "value": "#68d391",
+                    "type": "color"
+                },
+                "500": {
+                    "value": "#48bb78",
+                    "type": "color"
+                },
+                "600": {
+                    "value": "#38a169",
+                    "type": "color"
+                },
+                "700": {
+                    "value": "#2f855a",
+                    "type": "color"
+                },
+                "800": {
+                    "value": "#276749",
+                    "type": "color"
+                },
+                "900": {
+                    "value": "#22543d",
+                    "type": "color"
+                }
+            },
+            "teal": {
+                "100": {
+                    "value": "#e6fffa",
+                    "type": "color"
+                },
+                "200": {
+                    "value": "#b2f5ea",
+                    "type": "color"
+                },
+                "300": {
+                    "value": "#81e6d9",
+                    "type": "color"
+                },
+                "400": {
+                    "value": "#4fd1c5",
+                    "type": "color"
+                },
+                "500": {
+                    "value": "#38b2ac",
+                    "type": "color"
+                },
+                "600": {
+                    "value": "#319795",
+                    "type": "color"
+                },
+                "700": {
+                    "value": "#2c7a7b",
+                    "type": "color"
+                },
+                "800": {
+                    "value": "#285e61",
+                    "type": "color"
+                },
+                "900": {
+                    "value": "#234e52",
+                    "type": "color"
+                }
+            },
+            "blue": {
+                "100": {
+                    "value": "#ebf8ff",
+                    "type": "color"
+                },
+                "200": {
+                    "value": "#bee3f8",
+                    "type": "color"
+                },
+                "300": {
+                    "value": "#90cdf4",
+                    "type": "color"
+                },
+                "400": {
+                    "value": "#63b3ed",
+                    "type": "color"
+                },
+                "500": {
+                    "value": "#4299e1",
+                    "type": "color"
+                },
+                "600": {
+                    "value": "#3182ce",
+                    "type": "color"
+                },
+                "700": {
+                    "value": "#2b6cb0",
+                    "type": "color"
+                },
+                "800": {
+                    "value": "#2c5282",
+                    "type": "color"
+                },
+                "900": {
+                    "value": "#2a4365",
+                    "type": "color"
+                }
+            },
+            "indigo": {
+                "100": {
+                    "value": "#ebf4ff",
+                    "type": "color"
+                },
+                "200": {
+                    "value": "#c3dafe",
+                    "type": "color"
+                },
+                "300": {
+                    "value": "#a3bffa",
+                    "type": "color"
+                },
+                "400": {
+                    "value": "#7f9cf5",
+                    "type": "color"
+                },
+                "500": {
+                    "value": "#667eea",
+                    "type": "color"
+                },
+                "600": {
+                    "value": "#5a67d8",
+                    "type": "color"
+                },
+                "700": {
+                    "value": "#4c51bf",
+                    "type": "color"
+                },
+                "800": {
+                    "value": "#434190",
+                    "type": "color"
+                },
+                "900": {
+                    "value": "#3c366b",
+                    "type": "color"
+                }
+            },
+            "purple": {
+                "100": {
+                    "value": "#faf5ff",
+                    "type": "color"
+                },
+                "200": {
+                    "value": "#e9d8fd",
+                    "type": "color"
+                },
+                "300": {
+                    "value": "#d6bcfa",
+                    "type": "color"
+                },
+                "400": {
+                    "value": "#b794f4",
+                    "type": "color"
+                },
+                "500": {
+                    "value": "#9f7aea",
+                    "type": "color"
+                },
+                "600": {
+                    "value": "#805ad5",
+                    "type": "color"
+                },
+                "700": {
+                    "value": "#6b46c1",
+                    "type": "color"
+                },
+                "800": {
+                    "value": "#553c9a",
+                    "type": "color"
+                },
+                "900": {
+                    "value": "#44337a",
+                    "type": "color"
+                }
+            },
+            "pink": {
+                "100": {
+                    "value": "#fff5f7",
+                    "type": "color"
+                },
+                "200": {
+                    "value": "#fed7e2",
+                    "type": "color"
+                },
+                "300": {
+                    "value": "#fbb6ce",
+                    "type": "color"
+                },
+                "400": {
+                    "value": "#f687b3",
+                    "type": "color"
+                },
+                "500": {
+                    "value": "#ed64a6",
+                    "type": "color"
+                },
+                "600": {
+                    "value": "#d53f8c",
+                    "type": "color"
+                },
+                "700": {
+                    "value": "#b83280",
+                    "type": "color"
+                },
+                "800": {
+                    "value": "#97266d",
+                    "type": "color"
+                },
+                "900": {
+                    "value": "#702459",
+                    "type": "color"
+                }
+            }
+        },
+        "opacity": {
+            "low": {
+                "value": "10%",
+                "type": "opacity"
+            },
+            "md": {
+                "value": "50%",
+                "type": "opacity"
+            },
+            "high": {
+                "value": "90%",
+                "type": "opacity"
+            }
+        },
+        "fontFamilies": {
+            "heading": {
+                "value": "Inter",
+                "type": "fontFamilies"
+            },
+            "body": {
+                "value": "Roboto",
+                "type": "fontFamilies"
+            }
+        },
+        "lineHeights": {
+            "heading": {
+                "value": "110%",
+                "type": "lineHeights"
+            },
+            "body": {
+                "value": "140%",
+                "type": "lineHeights"
+            }
+        },
+        "letterSpacing": {
+            "default": {
+                "value": "0",
+                "type": "letterSpacing"
+            },
+            "increased": {
+                "value": "150%",
+                "type": "letterSpacing"
+            },
+            "decreased": {
+                "value": "-5%",
+                "type": "letterSpacing"
+            }
+        },
+        "paragraphSpacing": {
+            "h1": {
+                "value": "32",
+                "type": "paragraphSpacing"
+            },
+            "h2": {
+                "value": "26",
+                "type": "paragraphSpacing"
+            }
+        },
+        "fontWeights": {
+            "headingRegular": {
+                "value": "Regular",
+                "type": "fontWeights"
+            },
+            "headingBold": {
+                "value": "Bold",
+                "type": "fontWeights"
+            },
+            "bodyRegular": {
+                "value": "Regular",
+                "type": "fontWeights"
+            },
+            "bodyBold": {
+                "value": "Bold",
+                "type": "fontWeights"
+            }
+        },
+        "fontSizes": {
+            "h1": {
+                "value": "{fontSizes.h2} * 1.25",
+                "type": "fontSizes"
+            },
+            "h2": {
+                "value": "{fontSizes.h3} * 1.25",
+                "type": "fontSizes"
+            },
+            "h3": {
+                "value": "{fontSizes.h4} * 1.25",
+                "type": "fontSizes"
+            },
+            "h4": {
+                "value": "{fontSizes.h5} * 1.25",
+                "type": "fontSizes"
+            },
+            "h5": {
+                "value": "{fontSizes.h6} * 1.25",
+                "type": "fontSizes"
+            },
+            "h6": {
+                "value": "{fontSizes.body} * 1",
+                "type": "fontSizes"
+            },
+            "body": {
+                "value": "16",
+                "type": "fontSizes"
+            },
+            "sm": {
+                "value": "{fontSizes.body} * 0.85",
+                "type": "fontSizes"
+            },
+            "xs": {
+                "value": "{fontSizes.body} * 0.65",
+                "type": "fontSizes"
+            }
+        },
+        "typography": {
+            "H1": {
+                "Bold": {
+                    "type": "typography",
+                    "value": {
+                        "fontFamily": "{fontFamilies.heading}",
+                        "fontWeight": "{fontWeights.headingBold}",
+                        "lineHeight": "{lineHeights.heading}",
+                        "fontSize": "{fontSizes.h1}",
+                        "paragraphSpacing": "{paragraphSpacing.h1}",
+                        "letterSpacing": "{letterSpacing.decreased}"
+                    }
+                },
+                "Regular": {
+                    "type": "typography",
+                    "value": {
+                        "fontFamily": "{fontFamilies.heading}",
+                        "fontWeight": "{fontWeights.headingRegular}",
+                        "lineHeight": "{lineHeights.heading}",
+                        "fontSize": "{fontSizes.h1}",
+                        "paragraphSpacing": "{paragraphSpacing.h1}",
+                        "letterSpacing": "{letterSpacing.decreased}"
+                    }
+                }
+            },
+            "H2": {
+                "Bold": {
+                    "type": "typography",
+                    "value": {
+                        "fontFamily": "{fontFamilies.heading}",
+                        "fontWeight": "{fontWeights.headingBold}",
+                        "lineHeight": "{lineHeights.heading}",
+                        "fontSize": "{fontSizes.h2}",
+                        "paragraphSpacing": "{paragraphSpacing.h2}",
+                        "letterSpacing": "{letterSpacing.decreased}"
+                    }
+                },
+                "Regular": {
+                    "type": "typography",
+                    "value": {
+                        "fontFamily": "{fontFamilies.heading}",
+                        "fontWeight": "{fontWeights.headingRegular}",
+                        "lineHeight": "{lineHeights.heading}",
+                        "fontSize": "{fontSizes.h2}",
+                        "paragraphSpacing": "{paragraphSpacing.h2}",
+                        "letterSpacing": "{letterSpacing.decreased}"
+                    }
+                }
+            },
+            "Body": {
+                "type": "typography",
+                "value": {
+                    "fontFamily": "{fontFamilies.body}",
+                    "fontWeight": "{fontWeights.bodyRegular}",
+                    "lineHeight": "{lineHeights.heading}",
+                    "fontSize": "{fontSizes.body}",
+                    "paragraphSpacing": "{paragraphSpacing.h2}"
+                }
+            }
+        }
     },
-    "sizing": {
-      "scale": {
-        "value": "1.5",
-        "type": "sizing"
-      },
-      "xs": {
-        "value": "4",
-        "type": "sizing"
-      },
-      "sm": {
-        "value": "{sizing.xs} * {sizing.scale}",
-        "type": "sizing"
-      },
-      "md": {
-        "value": "{sizing.sm} * {sizing.scale}",
-        "type": "sizing"
-      },
-      "lg": {
-        "value": "{sizing.md} * {sizing.scale}",
-        "type": "sizing"
-      },
-      "xl": {
-        "value": "{sizing.lg} * {sizing.scale}",
-        "type": "sizing"
-      }
+    "light": {
+        "fg": {
+            "default": {
+                "value": "{colors.black}",
+                "type": "color"
+            },
+            "muted": {
+                "value": "{colors.gray.700}",
+                "type": "color"
+            },
+            "subtle": {
+                "value": "{colors.gray.500}",
+                "type": "color"
+            }
+        },
+        "bg": {
+            "default": {
+                "value": "{colors.white}",
+                "type": "color"
+            },
+            "muted": {
+                "value": "{colors.gray.100}",
+                "type": "color"
+            },
+            "subtle": {
+                "value": "{colors.gray.200}",
+                "type": "color"
+            }
+        },
+        "accent": {
+            "default": {
+                "value": "{colors.indigo.400}",
+                "type": "color"
+            }
+        },
+        "shadows": {
+            "default": {
+                "value": "{colors.gray.900}",
+                "type": "color"
+            }
+        }
     },
-    "borderRadius": {
-      "sm": {
-        "value": "4",
-        "type": "borderRadius"
-      },
-      "lg": {
-        "value": "8",
-        "type": "borderRadius"
-      },
-      "xl": {
-        "value": "16",
-        "type": "borderRadius"
-      }
+    "dark": {
+        "fg": {
+            "default": {
+                "value": "{colors.white}",
+                "type": "color"
+            },
+            "muted": {
+                "value": "{colors.gray.300}",
+                "type": "color"
+            },
+            "subtle": {
+                "value": "{colors.gray.500}",
+                "type": "color"
+            }
+        },
+        "bg": {
+            "default": {
+                "value": "{colors.gray.900}",
+                "type": "color"
+            },
+            "muted": {
+                "value": "{colors.gray.700}",
+                "type": "color"
+            },
+            "subtle": {
+                "value": "{colors.gray.600}",
+                "type": "color"
+            }
+        },
+        "accent": {
+            "default": {
+                "value": "{colors.indigo.600}",
+                "type": "color"
+            }
+        },
+        "shadows": {
+            "default": {
+                "value": "{colors.gray.100}",
+                "type": "color"
+            }
+        }
     },
-    "borderWidth": {
-      "none": {
-        "value": "0",
-        "type": "borderWidth"
-      },
-      "xs": {
-        "value": "1",
-        "type": "borderWidth"
-      },
-      "sm": {
-        "value": "2",
-        "type": "borderWidth"
-      },
-      "md": {
-        "value": "4",
-        "type": "borderWidth"
-      },
-      "lg": {
-        "value": "8",
-        "type": "borderWidth"
-      }
+    "theme": {
+        "button": {
+            "primary": {
+                "background": {
+                    "value": "{accent.default}",
+                    "type": "color"
+                }
+            },
+            "ghost": {
+                "outline": {
+                    "value": "{fg.default}",
+                    "type": "color"
+                },
+                "text": {
+                    "value": "{fg.default}",
+                    "type": "color"
+                }
+            }
+        },
+        "borderWidth": {
+            "button": {
+                "ghost": {
+                    "value": "{borderWidth.md}",
+                    "type": "borderWidth"
+                }
+            }
+        },
+        "borderRadius": {
+            "button": {
+                "ghost": {
+                    "value": "{borderRadius.lg}",
+                    "type": "borderRadius"
+                }
+            },
+            "card": {
+                "value": "{borderRadius.sm}",
+                "type": "borderRadius"
+            }
+        },
+        "fontSizes": {
+            "card": {
+                "title": {
+                    "value": "{fontSizes.sm}",
+                    "type": "fontSizes"
+                },
+                "content": {
+                    "value": "{fontSizes.xs}",
+                    "type": "fontSizes"
+                }
+            }
+        },
+        "boxShadow": {
+            "default": {
+                "value": [{
+                        "x": 5,
+                        "y": 5,
+                        "spread": 3,
+                        "color": "rgba({shadows.default}, 0.15)",
+                        "blur": 5,
+                        "type": "dropShadow"
+                    },
+                    {
+                        "x": 4,
+                        "y": 4,
+                        "spread": 6,
+                        "color": "#00000033",
+                        "blur": 5,
+                        "type": "innerShadow"
+                    }
+                ],
+                "type": "boxShadow"
+            }
+        }
     },
-    "colors": {
-      "black": {
-        "value": "#000000",
-        "type": "color"
-      },
-      "white": {
-        "value": "#ffffff",
-        "type": "color"
-      },
-      "gray": {
-        "100": {
-          "value": "#f7fafc",
-          "type": "color"
+    "$themes": [{
+            "id": "079b44a8b28ed46aff5be1542d750aaa108d08e1",
+            "name": "Brand A - Light",
+            "selectedTokenSets": {
+                "global": "source",
+                "light": "enabled",
+                "dark": "disabled",
+                "theme": "disabled"
+            },
+            "$figmaStyleReferences": {}
         },
-        "200": {
-          "value": "#edf2f7",
-          "type": "color"
-        },
-        "300": {
-          "value": "#e2e8f0",
-          "type": "color"
-        },
-        "400": {
-          "value": "#cbd5e0",
-          "type": "color"
-        },
-        "500": {
-          "value": "#a0aec0",
-          "type": "color"
-        },
-        "600": {
-          "value": "#718096",
-          "type": "color"
-        },
-        "700": {
-          "value": "#4a5568",
-          "type": "color"
-        },
-        "800": {
-          "value": "#2d3748",
-          "type": "color"
-        },
-        "900": {
-          "value": "#1a202c",
-          "type": "color"
+        {
+            "id": "d7f7ed73c544a76604e81ff7a6be59bc9ab43fad",
+            "name": "Brand A - Dark",
+            "selectedTokenSets": {
+                "global": "source",
+                "light": "disabled",
+                "dark": "enabled",
+                "theme": "disabled"
+            },
+            "$figmaStyleReferences": {}
         }
-      },
-      "red": {
-        "100": {
-          "value": "#fff5f5",
-          "type": "color"
-        },
-        "200": {
-          "value": "#fed7d7",
-          "type": "color"
-        },
-        "300": {
-          "value": "#feb2b2",
-          "type": "color"
-        },
-        "400": {
-          "value": "#fc8181",
-          "type": "color"
-        },
-        "500": {
-          "value": "#f56565",
-          "type": "color"
-        },
-        "600": {
-          "value": "#e53e3e",
-          "type": "color"
-        },
-        "700": {
-          "value": "#c53030",
-          "type": "color"
-        },
-        "800": {
-          "value": "#9b2c2c",
-          "type": "color"
-        },
-        "900": {
-          "value": "#742a2a",
-          "type": "color"
-        }
-      },
-      "orange": {
-        "100": {
-          "value": "#fffaf0",
-          "type": "color"
-        },
-        "200": {
-          "value": "#feebc8",
-          "type": "color"
-        },
-        "300": {
-          "value": "#fbd38d",
-          "type": "color"
-        },
-        "400": {
-          "value": "#f6ad55",
-          "type": "color"
-        },
-        "500": {
-          "value": "#ed8936",
-          "type": "color"
-        },
-        "600": {
-          "value": "#dd6b20",
-          "type": "color"
-        },
-        "700": {
-          "value": "#c05621",
-          "type": "color"
-        },
-        "800": {
-          "value": "#9c4221",
-          "type": "color"
-        },
-        "900": {
-          "value": "#7b341e",
-          "type": "color"
-        }
-      },
-      "yellow": {
-        "100": {
-          "value": "#fffff0",
-          "type": "color"
-        },
-        "200": {
-          "value": "#fefcbf",
-          "type": "color"
-        },
-        "300": {
-          "value": "#faf089",
-          "type": "color"
-        },
-        "400": {
-          "value": "#f6e05e",
-          "type": "color"
-        },
-        "500": {
-          "value": "#ecc94b",
-          "type": "color"
-        },
-        "600": {
-          "value": "#d69e2e",
-          "type": "color"
-        },
-        "700": {
-          "value": "#b7791f",
-          "type": "color"
-        },
-        "800": {
-          "value": "#975a16",
-          "type": "color"
-        },
-        "900": {
-          "value": "#744210",
-          "type": "color"
-        }
-      },
-      "green": {
-        "100": {
-          "value": "#f0fff4",
-          "type": "color"
-        },
-        "200": {
-          "value": "#c6f6d5",
-          "type": "color"
-        },
-        "300": {
-          "value": "#9ae6b4",
-          "type": "color"
-        },
-        "400": {
-          "value": "#68d391",
-          "type": "color"
-        },
-        "500": {
-          "value": "#48bb78",
-          "type": "color"
-        },
-        "600": {
-          "value": "#38a169",
-          "type": "color"
-        },
-        "700": {
-          "value": "#2f855a",
-          "type": "color"
-        },
-        "800": {
-          "value": "#276749",
-          "type": "color"
-        },
-        "900": {
-          "value": "#22543d",
-          "type": "color"
-        }
-      },
-      "teal": {
-        "100": {
-          "value": "#e6fffa",
-          "type": "color"
-        },
-        "200": {
-          "value": "#b2f5ea",
-          "type": "color"
-        },
-        "300": {
-          "value": "#81e6d9",
-          "type": "color"
-        },
-        "400": {
-          "value": "#4fd1c5",
-          "type": "color"
-        },
-        "500": {
-          "value": "#38b2ac",
-          "type": "color"
-        },
-        "600": {
-          "value": "#319795",
-          "type": "color"
-        },
-        "700": {
-          "value": "#2c7a7b",
-          "type": "color"
-        },
-        "800": {
-          "value": "#285e61",
-          "type": "color"
-        },
-        "900": {
-          "value": "#234e52",
-          "type": "color"
-        }
-      },
-      "blue": {
-        "100": {
-          "value": "#ebf8ff",
-          "type": "color"
-        },
-        "200": {
-          "value": "#bee3f8",
-          "type": "color"
-        },
-        "300": {
-          "value": "#90cdf4",
-          "type": "color"
-        },
-        "400": {
-          "value": "#63b3ed",
-          "type": "color"
-        },
-        "500": {
-          "value": "#4299e1",
-          "type": "color"
-        },
-        "600": {
-          "value": "#3182ce",
-          "type": "color"
-        },
-        "700": {
-          "value": "#2b6cb0",
-          "type": "color"
-        },
-        "800": {
-          "value": "#2c5282",
-          "type": "color"
-        },
-        "900": {
-          "value": "#2a4365",
-          "type": "color"
-        }
-      },
-      "indigo": {
-        "100": {
-          "value": "#ebf4ff",
-          "type": "color"
-        },
-        "200": {
-          "value": "#c3dafe",
-          "type": "color"
-        },
-        "300": {
-          "value": "#a3bffa",
-          "type": "color"
-        },
-        "400": {
-          "value": "#7f9cf5",
-          "type": "color"
-        },
-        "500": {
-          "value": "#667eea",
-          "type": "color"
-        },
-        "600": {
-          "value": "#5a67d8",
-          "type": "color"
-        },
-        "700": {
-          "value": "#4c51bf",
-          "type": "color"
-        },
-        "800": {
-          "value": "#434190",
-          "type": "color"
-        },
-        "900": {
-          "value": "#3c366b",
-          "type": "color"
-        }
-      },
-      "purple": {
-        "100": {
-          "value": "#faf5ff",
-          "type": "color"
-        },
-        "200": {
-          "value": "#e9d8fd",
-          "type": "color"
-        },
-        "300": {
-          "value": "#d6bcfa",
-          "type": "color"
-        },
-        "400": {
-          "value": "#b794f4",
-          "type": "color"
-        },
-        "500": {
-          "value": "#9f7aea",
-          "type": "color"
-        },
-        "600": {
-          "value": "#805ad5",
-          "type": "color"
-        },
-        "700": {
-          "value": "#6b46c1",
-          "type": "color"
-        },
-        "800": {
-          "value": "#553c9a",
-          "type": "color"
-        },
-        "900": {
-          "value": "#44337a",
-          "type": "color"
-        }
-      },
-      "pink": {
-        "100": {
-          "value": "#fff5f7",
-          "type": "color"
-        },
-        "200": {
-          "value": "#fed7e2",
-          "type": "color"
-        },
-        "300": {
-          "value": "#fbb6ce",
-          "type": "color"
-        },
-        "400": {
-          "value": "#f687b3",
-          "type": "color"
-        },
-        "500": {
-          "value": "#ed64a6",
-          "type": "color"
-        },
-        "600": {
-          "value": "#d53f8c",
-          "type": "color"
-        },
-        "700": {
-          "value": "#b83280",
-          "type": "color"
-        },
-        "800": {
-          "value": "#97266d",
-          "type": "color"
-        },
-        "900": {
-          "value": "#702459",
-          "type": "color"
-        }
-      }
-    },
-    "opacity": {
-      "low": {
-        "value": "10%",
-        "type": "opacity"
-      },
-      "md": {
-        "value": "50%",
-        "type": "opacity"
-      },
-      "high": {
-        "value": "90%",
-        "type": "opacity"
-      }
-    },
-    "fontFamilies": {
-      "heading": {
-        "value": "Inter",
-        "type": "fontFamilies"
-      },
-      "body": {
-        "value": "Roboto",
-        "type": "fontFamilies"
-      }
-    },
-    "lineHeights": {
-      "heading": {
-        "value": "110%",
-        "type": "lineHeights"
-      },
-      "body": {
-        "value": "140%",
-        "type": "lineHeights"
-      }
-    },
-    "letterSpacing": {
-      "default": {
-        "value": "0",
-        "type": "letterSpacing"
-      },
-      "increased": {
-        "value": "150%",
-        "type": "letterSpacing"
-      },
-      "decreased": {
-        "value": "-5%",
-        "type": "letterSpacing"
-      }
-    },
-    "paragraphSpacing": {
-      "h1": {
-        "value": "32",
-        "type": "paragraphSpacing"
-      },
-      "h2": {
-        "value": "26",
-        "type": "paragraphSpacing"
-      }
-    },
-    "fontWeights": {
-      "headingRegular": {
-        "value": "Regular",
-        "type": "fontWeights"
-      },
-      "headingBold": {
-        "value": "Bold",
-        "type": "fontWeights"
-      },
-      "bodyRegular": {
-        "value": "Regular",
-        "type": "fontWeights"
-      },
-      "bodyBold": {
-        "value": "Bold",
-        "type": "fontWeights"
-      }
-    },
-    "fontSizes": {
-      "h1": {
-        "value": "{fontSizes.h2} * 1.25",
-        "type": "fontSizes"
-      },
-      "h2": {
-        "value": "{fontSizes.h3} * 1.25",
-        "type": "fontSizes"
-      },
-      "h3": {
-        "value": "{fontSizes.h4} * 1.25",
-        "type": "fontSizes"
-      },
-      "h4": {
-        "value": "{fontSizes.h5} * 1.25",
-        "type": "fontSizes"
-      },
-      "h5": {
-        "value": "{fontSizes.h6} * 1.25",
-        "type": "fontSizes"
-      },
-      "h6": {
-        "value": "{fontSizes.body} * 1",
-        "type": "fontSizes"
-      },
-      "body": {
-        "value": "16",
-        "type": "fontSizes"
-      },
-      "sm": {
-        "value": "{fontSizes.body} * 0.85",
-        "type": "fontSizes"
-      },
-      "xs": {
-        "value": "{fontSizes.body} * 0.65",
-        "type": "fontSizes"
-      }
-    },
-    "typography": {
-      "H1": {
-        "Bold": {
-          "type": "typography",
-          "value": {
-            "fontFamily": "{fontFamilies.heading}",
-            "fontWeight": "{fontWeights.headingBold}",
-            "lineHeight": "{lineHeights.heading}",
-            "fontSize": "{fontSizes.h1}",
-            "paragraphSpacing": "{paragraphSpacing.h1}",
-            "letterSpacing": "{letterSpacing.decreased}"
-          }
-        },
-        "Regular": {
-          "type": "typography",
-          "value": {
-            "fontFamily": "{fontFamilies.heading}",
-            "fontWeight": "{fontWeights.headingRegular}",
-            "lineHeight": "{lineHeights.heading}",
-            "fontSize": "{fontSizes.h1}",
-            "paragraphSpacing": "{paragraphSpacing.h1}",
-            "letterSpacing": "{letterSpacing.decreased}"
-          }
-        }
-      },
-      "H2": {
-        "Bold": {
-          "type": "typography",
-          "value": {
-            "fontFamily": "{fontFamilies.heading}",
-            "fontWeight": "{fontWeights.headingBold}",
-            "lineHeight": "{lineHeights.heading}",
-            "fontSize": "{fontSizes.h2}",
-            "paragraphSpacing": "{paragraphSpacing.h2}",
-            "letterSpacing": "{letterSpacing.decreased}"
-          }
-        },
-        "Regular": {
-          "type": "typography",
-          "value": {
-            "fontFamily": "{fontFamilies.heading}",
-            "fontWeight": "{fontWeights.headingRegular}",
-            "lineHeight": "{lineHeights.heading}",
-            "fontSize": "{fontSizes.h2}",
-            "paragraphSpacing": "{paragraphSpacing.h2}",
-            "letterSpacing": "{letterSpacing.decreased}"
-          }
-        }
-      },
-      "Body": {
-        "type": "typography",
-        "value": {
-          "fontFamily": "{fontFamilies.body}",
-          "fontWeight": "{fontWeights.bodyRegular}",
-          "lineHeight": "{lineHeights.heading}",
-          "fontSize": "{fontSizes.body}",
-          "paragraphSpacing": "{paragraphSpacing.h2}"
-        }
-      }
+    ],
+    "$metadata": {
+        "tokenSetOrder": [
+            "global",
+            "light",
+            "dark",
+            "theme"
+        ]
     }
-  },
-  "light": {
-    "fg": {
-      "default": {
-        "value": "{colors.black}",
-        "type": "color"
-      },
-      "muted": {
-        "value": "{colors.gray.700}",
-        "type": "color"
-      },
-      "subtle": {
-        "value": "{colors.gray.500}",
-        "type": "color"
-      }
-    },
-    "bg": {
-      "default": {
-        "value": "{colors.white}",
-        "type": "color"
-      },
-      "muted": {
-        "value": "{colors.gray.100}",
-        "type": "color"
-      },
-      "subtle": {
-        "value": "{colors.gray.200}",
-        "type": "color"
-      }
-    },
-    "accent": {
-      "default": {
-        "value": "{colors.indigo.400}",
-        "type": "color"
-      }
-    },
-    "shadows": {
-      "default": {
-        "value": "{colors.gray.900}",
-        "type": "color"
-      }
-    }
-  },
-  "dark": {
-    "fg": {
-      "default": {
-        "value": "{colors.white}",
-        "type": "color"
-      },
-      "muted": {
-        "value": "{colors.gray.300}",
-        "type": "color"
-      },
-      "subtle": {
-        "value": "{colors.gray.500}",
-        "type": "color"
-      }
-    },
-    "bg": {
-      "default": {
-        "value": "{colors.gray.900}",
-        "type": "color"
-      },
-      "muted": {
-        "value": "{colors.gray.700}",
-        "type": "color"
-      },
-      "subtle": {
-        "value": "{colors.gray.600}",
-        "type": "color"
-      }
-    },
-    "accent": {
-      "default": {
-        "value": "{colors.indigo.600}",
-        "type": "color"
-      }
-    },
-    "shadows": {
-      "default": {
-        "value": "{colors.gray.100}",
-        "type": "color"
-      }
-    }
-  },
-  "theme": {
-    "button": {
-      "primary": {
-        "background": {
-          "value": "{accent.default}",
-          "type": "color"
-        }
-      },
-      "ghost": {
-        "outline": {
-          "value": "{fg.default}",
-          "type": "color"
-        },
-        "text": {
-          "value": "{fg.default}",
-          "type": "color"
-        }
-      }
-    },
-    "borderWidth": {
-      "button": {
-        "ghost": {
-          "value": "{borderWidth.md}",
-          "type": "borderWidth"
-        }
-      }
-    },
-    "borderRadius": {
-      "button": {
-        "ghost": {
-          "value": "{borderRadius.lg}",
-          "type": "borderRadius"
-        }
-      },
-      "card": {
-        "value": "{borderRadius.sm}",
-        "type": "borderRadius"
-      }
-    },
-    "fontSizes": {
-      "card": {
-        "title": {
-          "value": "{fontSizes.sm}",
-          "type": "fontSizes"
-        },
-        "content": {
-          "value": "{fontSizes.xs}",
-          "type": "fontSizes"
-        }
-      }
-    },
-    "boxShadow": {
-      "default": {
-        "value": [
-          {
-            "x": 5,
-            "y": 5,
-            "spread": 3,
-            "color": "rgba({shadows.default}, 0.15)",
-            "blur": 5,
-            "type": "dropShadow"
-          },
-          {
-            "x": 4,
-            "y": 4,
-            "spread": 6,
-            "color": "#00000033",
-            "blur": 5,
-            "type": "innerShadow"
-          }
-        ],
-        "type": "boxShadow"
-      }
-    }
-  },
-  "$themes": [
-    {
-      "id": "079b44a8b28ed46aff5be1542d750aaa108d08e1",
-      "name": "Brand A - Light",
-      "selectedTokenSets": {
-        "global": "source",
-        "light": "enabled",
-        "dark": "disabled",
-        "theme": "disabled"
-      },
-      "$figmaStyleReferences": {}
-    },
-    {
-      "id": "d7f7ed73c544a76604e81ff7a6be59bc9ab43fad",
-      "name": "Brand A - Dark",
-      "selectedTokenSets": {
-        "global": "source",
-        "light": "disabled",
-        "dark": "enabled",
-        "theme": "disabled"
-      },
-      "$figmaStyleReferences": {}
-    }
-  ],
-  "$metadata": {
-    "tokenSetOrder": [
-      "global",
-      "light",
-      "dark",
-      "theme"
-    ]
-  }
 }


### PR DESCRIPTION
This PR fixes:

- For typographies where line height was not provided, import now doesn't crash
- For radii that reference measures instead of radii, the resolution will now properly work, resolve to the desired value, and the reference will be thrown away (so a plain token is created instead). This works around the fact that references can't be of different types (ie. it is not possible to reference shadow into border etc.)
- Radii serialization for more complex cases (separate radii for each edge)