### PR TITLE
#token-studio: Fix building GenericTokenValue from fontWeight number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@supernovaio/supernova-sdk",
-    "version": "1.8.72",
+    "version": "1.8.75",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@supernovaio/supernova-sdk",
-            "version": "1.8.72",
+            "version": "1.8.75",
             "license": "MIT",
             "dependencies": {
                 "abab": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@supernovaio/supernova-sdk",
-    "version": "1.8.73",
+    "version": "1.8.75",
     "description": "Supernova.io Developer SDK",
     "main": "build/supernova-sdk-typescript.js",
     "typings": "build/Typescript/src/index.d.ts",

--- a/src/model/tokens/SDKGenericToken.ts
+++ b/src/model/tokens/SDKGenericToken.ts
@@ -73,7 +73,7 @@ export class GenericToken extends Token {
       customPropertyOverrides: []
     }
 
-    if (value) {
+    if (value !== undefined && value !== null) {
       // Raw value
       let tokenValue = this.genericValueFromDefinition(value)
       return new GenericToken(version, baseToken, tokenValue, undefined, properties, propertyValues)
@@ -89,7 +89,7 @@ export class GenericToken extends Token {
 
   static genericValueFromDefinition(definition: string): GenericTokenValue {
     return {
-      text: definition ? definition : '',
+      text: definition ? `${definition}` : '',
       referencedToken: null
     }
   }

--- a/src/tools/design-tokens/SDKToolsDesignTokensPlugin.ts
+++ b/src/tools/design-tokens/SDKToolsDesignTokensPlugin.ts
@@ -126,7 +126,17 @@ export class SupernovaToolsDesignTokensPlugin {
         throw new Error(`Unknown brand ${map.bindToBrand} provided in binding.\n\nAvailable brands in this design system: [${brands.map(b => `${b.name} (id: ${b.persistentId})`)}]`)
       }
       // Find the destination theme
-      let theme = themes.find(t => t.id === map.bindToTheme || (map.bindToTheme.toLowerCase().trim()) === t.name.toLowerCase().trim())
+      let matchedThemes = themes.filter(
+        t =>
+          t.brandId === brand.id &&
+          (t.id === map.bindToTheme ||
+            map.bindToTheme.toLowerCase().trim() === t.name.toLowerCase().trim() ||
+            map.bindToTheme.toLowerCase().trim() === t.codeName.toLowerCase().trim())
+      )
+      if (matchedThemes.length > 1) {
+        throw new Error(`Ambiguous theme ${map.bindToTheme} provided in binding.\n\nPlease, use unique name in mapping or rename theme name or code in Supernova.\n\nAvailable themes in this design system: ${brands.map(b => `Brand: ${b.name} (id: ${b.persistentId})\n${themes.filter(th => th.brandId == b.persistentId).map(t => `    Theme: ${t.name} (id: ${t.id})`)}`)}`)
+      }
+      let theme = matchedThemes[0]
       if (!theme) {
         throw new Error(`Unknown theme ${map.bindToTheme} provided in binding.\n\nAvailable themes in this design system: ${brands.map(b => `Brand: ${b.name} (id: ${b.persistentId})\n${themes.filter(th => th.brandId == b.persistentId).map(t => `    Theme: ${t.name} (id: ${t.id})`)}`)}`)
       }


### PR DESCRIPTION
## Changes
 - Example from [this ticket](https://linear.app/supernova-io/issue/PF-5/cli-bug-or-sicpa-issue-syncing-transformed-tokens) fails trying to import GenericToken. The reason is `fontWeights` uses number as value, and our GenericToken uses string. This transforms original `fontWeights` into string, so we can import it.
 - Fix retrieving theme during TS import, include `brandId` in filter. Otherwise, theme from other brand may be resolved and this breaks import.
 - Allow using `codeName` inside TS mapping for `supernovaTheme`. Still, throw an error in case of ambiguity: both theme with `codeName` and `name` were found.