### PR TITLE
ENG-933: Gradients with rgba with spaces as stops 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@supernovaio/supernova-sdk",
-    "version": "1.8.75",
+    "version": "1.8.76",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@supernovaio/supernova-sdk",
-            "version": "1.8.75",
+            "version": "1.8.76",
             "license": "MIT",
             "dependencies": {
                 "abab": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@supernovaio/supernova-sdk",
-    "version": "1.8.75",
+    "version": "1.8.76",
     "description": "Supernova.io Developer SDK",
     "main": "build/supernova-sdk-typescript.js",
     "typings": "build/Typescript/src/index.d.ts",

--- a/src/model/tokens/SDKGradientToken.ts
+++ b/src/model/tokens/SDKGradientToken.ts
@@ -118,6 +118,9 @@ export class GradientToken extends Token {
     // Parse raw gradient pieces
     const [gradientDegrees, ...colorStops] = definition
       .substring(definition.indexOf('(') + 1, definition.lastIndexOf(')'))
+      // There could be commas inside color def
+      // linear-gradient(180deg, rgba(0, 0, 0, 0) 50%, rgba(0, 0, 0, 0.8) 100%)
+      .replace(/, (?=[^()]*\))/g, ',')
       .split(', ')
 
     // Rotate 90 degrees

--- a/src/tools/design-tokens/SDKToolsDesignTokensPlugin.ts
+++ b/src/tools/design-tokens/SDKToolsDesignTokensPlugin.ts
@@ -128,7 +128,7 @@ export class SupernovaToolsDesignTokensPlugin {
       // Find the destination theme
       let matchedThemes = themes.filter(
         t =>
-          t.brandId === brand.id &&
+          t.brandId === brand.persistentId &&
           (t.id === map.bindToTheme ||
             map.bindToTheme.toLowerCase().trim() === t.name.toLowerCase().trim() ||
             map.bindToTheme.toLowerCase().trim() === t.codeName.toLowerCase().trim())

--- a/test-resources/figma-tokens/single-file-sync-using-names/tokens.json
+++ b/test-resources/figma-tokens/single-file-sync-using-names/tokens.json
@@ -101,6 +101,10 @@
                 "value": "linear-gradient(90deg, {colors.black} 0%, {colors.white} 100%)",
                 "type": "color"
             },
+            "gradient-spaces": {
+                "value": "linear-gradient(180deg, rgba(0, 0, 0, 0) 50%, rgba(0, 0, 0, 0.8) 100%)",
+                "type": "color"
+            },
             "gray": {
                 "100": {
                     "value": "#f7fafc",
@@ -794,7 +798,8 @@
         },
         "boxShadow": {
             "default": {
-                "value": [{
+                "value": [
+                    {
                         "x": 5,
                         "y": 5,
                         "spread": 3,
@@ -815,7 +820,8 @@
             }
         }
     },
-    "$themes": [{
+    "$themes": [
+        {
             "id": "079b44a8b28ed46aff5be1542d750aaa108d08e1",
             "name": "Light",
             "selectedTokenSets": {

--- a/test-resources/figma-tokens/single-file-sync/tokens.json
+++ b/test-resources/figma-tokens/single-file-sync/tokens.json
@@ -101,6 +101,10 @@
                 "value": "linear-gradient(90deg, {colors.black} 0%, {colors.white} 100%)",
                 "type": "color"
             },
+            "gradient-spaces": {
+                "value": "linear-gradient(180deg, rgba(0, 0, 0, 0) 50%, rgba(0, 0, 0, 0.8) 100%)",
+                "type": "color"
+            },
             "gray": {
                 "100": {
                     "value": "#f7fafc",
@@ -794,7 +798,8 @@
         },
         "boxShadow": {
             "default": {
-                "value": [{
+                "value": [
+                    {
                         "x": 5,
                         "y": 5,
                         "spread": 3,
@@ -815,7 +820,8 @@
             }
         }
     },
-    "$themes": [{
+    "$themes": [
+        {
             "id": "079b44a8b28ed46aff5be1542d750aaa108d08e1",
             "name": "Brand A - Light",
             "selectedTokenSets": {


### PR DESCRIPTION
## Changes
 - Fix gradient with rgba with spaces as stops, like `linear-gradient(180deg, rgba(0, 0, 0, 0) 50%, rgba(0, 0, 0, 0.8) 100%)`
 - Fix using `brand.persistentId` in theme filtering