### PR TITLE
ENG-1007: Show themed shadow tokens in documentation

### DIFF
--- a/src/core/resolvers/SDKTokenResolver.ts
+++ b/src/core/resolvers/SDKTokenResolver.ts
@@ -395,7 +395,14 @@ export class TokenResolver {
      */
 
     let theme = new TokenTheme(data, this.version)
-    theme.overriddenTokens = Array.from(this.resolvedOverrides.values())
+
+    const themeOverrides = Array.from(this.resolvedOverrides.values())
+
+    this.fixMultilayerShadowTokens(themeOverrides.filter(t => t.tokenType === TokenType.shadow) as Array<ShadowToken>)
+    this.fixMultilayerGradientTokens(themeOverrides.filter(t => t.tokenType === TokenType.gradient) as Array<GradientToken>)
+    this.fixMultilayerBlurTokens(themeOverrides.filter(t => t.tokenType === TokenType.blur) as Array<BlurToken>)
+
+    theme.overriddenTokens = themeOverrides
     return theme
   }
 


### PR DESCRIPTION
In documentation we show layer versions (`token.shadowLayers`) of Shadow tokens for values and previews.
So, the same fix that adds those layers should be applied not only to the usual tokens but to themed tokens as well

Before fix:
<img width="1359" alt="image" src="https://github.com/Supernova-Studio/sdk-typescript/assets/9402858/398b8a90-1cf5-45cf-a330-d316117ff912">

After fix:
<img width="1379" alt="image" src="https://github.com/Supernova-Studio/sdk-typescript/assets/9402858/56da7e5e-9ee1-4774-a53f-6cf36cfc44f5">
